### PR TITLE
Add key that was removed at some point

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -1859,6 +1859,7 @@
   }
 },
 "DND5E.title": "Dungeons & Dragons 5. Edition",
+"dnd5e-DE.ProficiencyAbbrev": "ÜB",
 "EFFECT.DND5E": {
 "StatusBleeding": "Bluten",	
 "StatusBurrowing": "Eingraben",


### PR DESCRIPTION
I noticed that in the NPC Character sheets the "Proficiency" on the top right was missing a key with a translation. After some digging inside the code and previous commits I noticed that a custom key is set because in German the value would be too long (typisch Deutsch). The key was already there once but got removed. So here it is again 🙂

Didn't test it but the key is still the same inside the code, so should be fine...

![GIF](https://media1.tenor.com/m/GElyvue_13cAAAAC/april-fools-joke.gif)

