### PR TITLE
Add missing translations for 4.1.2, Fix updated keys & typos

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -1,3390 +1,3416 @@
 {
-   "DOCUMENT.DND5E": {
-       "Activity": "Aktivität"
-   },
-   "TYPES.Actor.character": "Spielercharakter",
-   "TYPES.Actor.characterPl": "Spielercharaktere",
-   "TYPES.Actor.npc": "Nichtspielercharakter",
-   "TYPES.Actor.npcPl": "Nichtspielercharaktere",
-   "TYPES.Actor.vehicle": "Fahrzeug",
-   "TYPES.Actor.vehiclePl": "Fahrzeuge",
-   "TYPES.Actor.group": "Gruppe",
-   "TYPES.Actor.groupPl": "Gruppen",
-   "TYPES.ActiveEffect.enchantment": "Verzauberung",
-   "TYPES.ActiveEffect.enchantmentPl": "Verzauberungen",
-   "TYPES.Item.background": "Hintergrund",
-   "TYPES.Item.backgroundPl": "Hintergründe",
-   "TYPES.Item.class": "Klasse",
-   "TYPES.Item.classPl": "Klassen",
-   "TYPES.Item.consumable": "Verbrauchsgut",
-   "TYPES.Item.consumablePl": "Verbrauchsgüter",
-   "TYPES.Item.container": "Behälter",
-   "TYPES.Item.containerPl": "Behälter",
-   "TYPES.Item.equipment": "Ausrüstung",
-   "TYPES.Item.equipmentPl": "Ausrüstung",
-   "TYPES.Item.feat": "Merkmal",
-   "TYPES.Item.featurePl": "Merkmale",
-   "TYPES.Item.loot": "Beute",
-   "TYPES.Item.lootPl": "Beute",
-   "TYPES.Item.race": "Spezies",
-   "TYPES.Item.racePl": "Spezies",
-   "TYPES.Item.raceLegacy": "Volk",
-   "TYPES.Item.raceLegacyPl": "Völker",
-   "TYPES.Item.spell": "Zauber",
-   "TYPES.Item.spellPl": "Zauber",
-   "TYPES.Item.subclass": "Unterklasse",
-   "TYPES.Item.subclassPl": "Unterklassen",
-   "TYPES.Item.tool": "Werkzeug",
-   "TYPES.Item.toolPl": "Werkzeuge",
-   "TYPES.Item.weapon": "Waffe",
-   "TYPES.Item.weaponPl": "Waffen",
-   "DND5E.AC": "RK",
-   "DND5E.ATTACK": {
-       "Title": {
-           "one": "Angriff",
-           "other": "Angriffe"
-       },
-       "FIELDS": {
-           "attack": {
-               "label": "Angriffs-Details",
-               "ability": {
-                   "label": "Angriffsattribut",
-                   "hint": "Attribut, as für den Angriff und die Bestimmung des Schadens verwendet wird. Verfügbar mit @mod in Formeln."
-               },
-               "bonus": {
-                   "label": "Auf Treffer Bonus",
-                   "hint": "Bonus zum Angriffswurf für den Angriff hinzugefügt."
-               },
-               "critical": {
-                   "threshold": {
-                       "label": "Kritischer Schwellwert",
-                       "hint": "Minimum Wert auf dem W20, der benötigt wird, um einen Kritischen Treffer zu erzielen."
-                   }
-               },
-               "flat": {
-                   "label": "Pauschal auf Treffer",
-                   "hint": "Ignoriere den Attributsmodifikator, die Übung und alle anderen Boni des Akteurs und verwende nur den durch die Aktivität definierten Bonus, wenn du den Treffer berechnest."
-               },
-               "type": {
-                   "label": "Angriffszyp",
-                   "value": {
-                       "label": "Angriffstyp",
-                       "hint": "Handelt es sich um einen Nah- oder Fernkampfangriff?"
-                   },
-                   "classification": {
-                       "label": "Angriffsklassifizierung",
-                       "hint": "Handelt es sich um einen waffenlosen, einen Waffen- oder einen Zauberangriff?"
-                   }
-               }
-           },
-           "damage": {
-               "label": "Angriffsschaden",
-               "critical": {
-                   "bonus": {
-                       "label": "Zusätzlicher Kritischer Schaden",
-                       "hint": "Zusätzlicher Schaden der zugefügt wird, wenn ein kritischer Treffer gewürfelt wird. Wird zum Grundschaden oder zum ersten Teil des Schadens addiert."
-                   }
-               },
-               "includeBase": {
-                   "label": "Grundschaden inkludieren",
-                   "hint": "Inkludiere den Grundschaden des Items mit allen zusätzliche Schadensbestandteilen"
-               },
-               "parts": {
-                   "label": "Schadensbestandteile",
-                   "hint": "Individuelle Schadensbestandteile die in den Wurf inkludiert werden."
-               }
-           }
-       },
-       "Classification": {
-           "Spell": "Zauber",
-           "Unarmed": "Waffenlos",
-           "Weapon": "Waffe"
-       },
-       "Mode": {
-           "Label": "Angriffsmodus",
-           "Offhand": "Nebenhand",
-           "OneHanded": "Einhändig",
-           "Thrown": "Wurfwaffe",
-           "ThrownOffhand": "Nebenhand Wurfwaffe",
-           "TwoHanded": "Zweihändig"
-       },
-       "Type": {
-           "Melee": "Nahkampf",
-           "Ranged": "Fernkampf"
-       },
-       "Warning": {
-           "NoQuantity": "Versuch, mit einer Waffe mit einer Menge von Null anzugreifen."
-       }
-   },
-   "DND5E.AbbreviationCR": "HG",
-   "DND5E.AbbreviationConc": "Konz.",
-   "DND5E.AbbreviationDC": "SG",
-   "DND5E.AbbreviationKg": "kg",
-   "DND5E.AbbreviationLR": "LR",
-   "DND5E.AbbreviationLbs": "Pf.",
-   "DND5E.AbbreviationLevel": "St.",
-   "DND5E.AbbreviationSR": "SR",
-   "DND5E.Abilities": "Attribute",
-   "DND5E.Ability": "Attribut",
-   "DND5E.AbilityBonuses": "Attributsboni",
-   "DND5E.AbilityCha": "Charisma",
-   "DND5E.AbilityChaAbbr": "Cha",
-   "DND5E.AbilityCheckBonus": "Probenbonus",
-   "DND5E.AbilityCheckConfigurationHint": "Probenboni bearbeiten.",
-   "DND5E.AbilityCheckConfigure": "{ability} Fähigkeitsproben",
-   "DND5E.AbilityCheckGlobalBonusHint": "Dieser Bonus gilt für alle Attributswürfe dieses Akteurs.",
-   "DND5E.AbilityCon": "Konstitution",
-   "DND5E.AbilityConAbbr": "Kon",
-   "DND5E.AbilityConfigurationHint": "Übung für Rettungswürfe und Boni für Rettungswürfe und Proben konfigurieren.",
-   "DND5E.AbilityConfigure": "Fähigkeits- und Rettungswürfe bearbeiten",
-   "DND5E.AbilityConfigureTitle": "{ability} Rettungswürfe und Proben bearbeiten",
-   "DND5E.AbilityDex": "Geschicklichkeit",
-   "DND5E.AbilityDexAbbr": "Ges",
-   "DND5E.AbilityHon": "Ehre",
-   "DND5E.AbilityHonAbbr": "Ehr",
-   "DND5E.AbilityInt": "Intelligenz",
-   "DND5E.AbilityIntAbbr": "Int",
-   "DND5E.AbilityModifier": "Attributsmodifikator",
-   "DND5E.AbilityPromptText": "Welche Art von {ability} Wurf?",
-   "DND5E.AbilityPromptTitle": "{ability} Attributswurf",
-   "DND5E.AbilitySan": "Geistige Gesundheit",
-   "DND5E.AbilitySanAbbr": "Ges",
-   "DND5E.AbilitySaveConfigure": "{ability} Rettungswürfe",
-   "DND5E.AbilityScore": "Attributswert",
-   "DND5E.AbilityScoreL": "{ability} Wert",
-   "DND5E.AbilityScoreMax": "Maximaler Attributswert",
-   "DND5E.AbilityScorePl": "Attributswerte",
-   "DND5E.AbilityStr": "Stärke",
-   "DND5E.AbilityStrAbbr": "Stä",
-   "DND5E.AbilityUseCast": "Zauber wirken",
-   "DND5E.AbilityUseChargedHint": "{type} ist aufgeladen und bereit zur Verwendung!",
-   "DND5E.AbilityUseChargesLabel": "{value} Ladungen",
-   "DND5E.AbilityUseConfig": "Nutzungen bearbeiten",
-   "DND5E.AbilityUseConsumableChargeHint": "Bei Nutzung dieses {type} wird eine Ladung verbraucht und {value} verbleiben.",
-   "DND5E.AbilityUseConsumableDestroyHint": "Bei Nutzung {type} wird die letzte Anwendung verbraucht und der Gegenstand zerstört.",
-   "DND5E.AbilityUseConsumableDestroyResourceHint": "Bei Nutzung vom {type} wird die letzte Ladung von {name} verbraucht und zerstört.",
-   "DND5E.AbilityUseConsumableLabel": "{max} per {per}",
-   "DND5E.AbilityUseConsumableQuantityHint": "Bei Nutzung dieses {type} wird eine Anwendung verbraucht und {quantity} verbleiben",
-   "DND5E.AbilityUseConsume": "Verfügbare Ladungen verbrauchen?",
-   "DND5E.AbilityUseConsumeAction": "Ladung verbrauchen",
-   "DND5E.AbilityUseHint": "Bearbeite Verwendung von {type} {name}.",
-   "DND5E.AbilityUseNormalHint": "{type} hat {value} von {max} Anwendungen pro {per} verbleibend.",
-   "DND5E.AbilityUseRechargeHint": "{type} ist verbraucht und muss aufgeladen werden!",
-   "DND5E.AbilityUseUnavailableHint": "Es sind keine Anwendungen mehr vorhanden!",
-   "DND5E.AbilityUseUse": "Fertigkeit benutzen",
-   "DND5E.AbilityWis": "Weisheit",
-   "DND5E.AbilityWisAbbr": "Wei",
-   "DND5E.Action": "Aktion",
-   "DND5E.ActionAbbr": "A",
-   "DND5E.ActionAbil": "Attributswurf",
-   "DND5E.ActionEnch": "Verzaubern",
-   "DND5E.ActionHeal": "Heilung",
-   "DND5E.ActionMSAK": "Nahkampf-Zauberangriff",
-   "DND5E.ActionMWAK": "Nahkampf-Waffenangriff",
-   "DND5E.ActionOther": "Andere",
-   "DND5E.ActionPl": "Aktionen",
-   "DND5E.ActionRSAK": "Fernkampf-Zauberangriff",
-   "DND5E.ActionRWAK": "Fernkampf-Waffenangriff",
-   "DND5E.ActionSave": "Rettungswurf",
-   "DND5E.ActionSumm": "Beschwören",
-   "DND5E.ActionUtil": "Utility",
-   "DND5E.ActionWarningNoItem": "Das angefragte Objekt {item} existiert nicht mehr bei Charakter {name}",
-   "DND5E.ActionWarningNoToken": "Um diese Option zu verwenden, brauchst du Kontrolle über mindestens eine Figur.",
-   "DND5E.ACTIVATION": {
-       "FIELDS": {
-           "activation": {
-               "label": "Aktivierung",
-               "condition": {
-                   "label": "Aktivierungsbedingung",
-                   "hint": "Bedingung, die erfüllt sein muss, um diese Aktivität zu aktivieren."
-               },
-               "override": {
-                   "label": "Aktivierung überschreiben",
-                   "hint": "Verwende diese Aktivierungswerte anstelle der Werte des Items, wenn du diese Aktivität verwendest."
-               },
-               "type": {
-                   "label": "Aktivierungskosten",
-                   "hint": "Aktivierungstyp (z.B. Aktion, Legendäre Aktion, Minuten)"
-               },
-               "value": {
-                   "label": "Aktivierungswert",
-                   "hint": "Skalarwert, der mit der Aktivierung verbunden ist."
-               }
-           }
-       },
-       "Category": {
-           "Standard": "Standard",
-           "Time": "Zeit",
-           "Monster": "Monster",
-           "Vehicle": "Fahrzeug"
-       }
-   },
-   "DND5E.ACTIVITY": {
-       "Action": {
-           "Create": "Erstelle Aktivität",
-           "Delete": "Entferne Aktivität"
-       },
-       "Title": {
-           "one": "Aktivität",
-           "other": "Aktivitäten"
-       },
-       "FIELDS": {
-           "description": {
-               "label": "Beschreibung",
-               "chatFlavor": {
-                   "label": "Chat Flavortext",
-                   "hint": "Zusätzlicher Text, der in der Aktivierungs-Chatnachricht angezeigt wird."
-               }
-           },
-           "effects": {
-               "label": "Effekt anwenden"
-           },
-           "img": {
-               "label": "Icon"
-           },
-           "name": {
-               "label": "Name"
-           }
-       },
-       "SECTIONS": {
-           "Activation": "Aktivierung",
-           "Behavior": "Verhalten",
-           "Effect": "Effekt",
-           "Identity": "Identität",
-           "Time": "Zeit"
-       }
-   },
-   "DND5E.ActiveEffectOverrideWarning": "Dieser Wert wird von einem Aktive Effekt beeinflusst und kann nicht bearbeitet werden. Zum Bearbeiten Effekt deaktivieren.",
-   "DND5E.ActorWarningInvalidItem": "{itemType} Items können nicht zu {actorType} hinzugefügt werden.",
-   "DND5E.ActorWarningSingleton": "Nur ein {itemType} kann zum {actorType} hinzugefügt werden.",
-   "DND5E.Add": "Neu",
-   "DND5E.AdditionalControls": "Zusätzliche Steuerelemente",
-   "DND5E.AdditionalSettings": "Zusätzliche Einstellungen",
-   "DND5E.AddEmbeddedItemPromptHint": "Diese Items zum Charakterbogen hinzufügen?",
-   "DND5E.Advanced": "Erweitert",
-   "DND5E.ADVANCEMENT": {
-       "AbilityScoreImprovement": {
-           "Title": "Attributswerterhöhung",
-           "Hint": "Erlaubt dem Spieler, einen oder mehrere Attributswerte zu erhöhen oder ein optionales Talent zu wählen.",
-           "CapDisplay": {
-               "one": "Maximal {points} Punkte pro Attribut",
-               "other": "Maximal {points} Punkte pro Wert"
-           },
-           "Feat": {
-               "Hint": "Talent hierher ziehen um es statt einer Erhöhung der Attributswerte zu wählen."
-           },
-           "FIELDS": {
-               "cap": {
-                   "label": "Punktobergrenze",
-                   "hint": "Maximale Anzahl von Punkten, die ein Spieler einem einzelnen Attribut zuordnen kann."
-               },
-               "locked": {
-                   "label": "Gesperrt",
-                   "hint": "Attributswert kann nicht erhöht werden."
-               },
-               "fixed": {
-                   "label": "Feste Erhöhung",
-                   "hint": "Attribute, die um einen festen Wert erhöht werden und während des Vorgangs nicht manuell erhöht werden können."
-               },
-               "points": {
-                   "label": "Punkte",
-                   "hint": "Anzahl der Punkte, die einem freigeschalteten Attributswert zugewiesen werden können.",
-                   "decrease": "Punkte verringern",
-                   "increase": "Punkte erhöhen"
-               }
-           },
-           "LockedHint": "Werte sind nicht veränderbar, wenn ein Talent gewählt wurde.",
-           "PointsRemaining": {
-               "one": "{points} Punkt verbleibend",
-               "other": "{points} Punkte verbleibend"
-           },
-           "Warning": {
-               "Level": "Muss mindestens Stufe {Stufe} sein, um dieses Merkmal zu erhalten.",
-               "Type": "Nur Merkmale vom Typ \"Talent\" können gewählt werden."
-           }
-       },
-       "SPELLCONFIG": {
-           "FIELDS": {
-               "uses": {
-                   "requireSlot": {
-                       "label": "Benötigt Zauberplatz",
-                       "hint": "Erfordert einen Zauberplatz, der ausgegeben werden muss, wenn die Limitierte Nutzungen genutzt werden. Wenn das Kästchen nicht markiert ist, handelt es sich um zusätzliche kostenlose Verwendungen, die keinen Platz verbrauchen."
-                   }
-               }
-           },
-           "FreeCasting": "Kostenloses Zauberwirken"
-       },
-       "Subclass": {
-           "Title": "Unterklasse",
-           "Hint": "Gib an, auf welcher Stufe diese Klasse ihre Unterklasse erhält.",
-           "FlowHint": "Wähle eine Unterklasse im Merkmale Reiter nachdem der Stufenaufstieg abgeschlossen ist."
-       }
-   },
-   "DND5E.AdvancementChoices": "Auswahl",
-   "DND5E.AdvancementClassRestriction": "Klassenbeschränkung",
-   "DND5E.AdvancementClassRestrictionNone": "Alle Klassen",
-   "DND5E.AdvancementClassRestrictionPrimary": "Nur ursprüngliche Klasse",
-   "DND5E.AdvancementClassRestrictionSecondary": "Nur Klassenkombinationen",
-   "DND5E.AdvancementConfigurationActionDisable": "Konfiguration deaktivieren",
-   "DND5E.AdvancementConfigurationActionEnable": "Konfiguration aktivieren",
-   "DND5E.AdvancementConfigurationModeDisabled": "Konfiguration deaktiviert",
-   "DND5E.AdvancementConfigurationModeEnabled": "Konfiguration aktiviert",
-   "DND5E.AdvancementConfigureAllowDrops": "Reinziehen erlauben",
-   "DND5E.AdvancementConfigureAllowDropsHint": "Dürfen Spieler selbst Items in diesen Fortschritt ziehen?",
-   "DND5E.AdvancementConfigureDropAreaHint": "Hier Items hinziehen, um sie der möglichen Auswahl für Spieler hinzuzufügen.",
-   "DND5E.AdvancementConfigureTitle": "{item} Fortschritt bearbeiten",
-   "DND5E.AdvancementConfiguredComplete": "Vollständig konfiguriert",
-   "DND5E.AdvancementConfiguredIncomplete": "Nicht konfiguriert",
-   "DND5E.AdvancementControlCreate": "Erstelle Fortschritt",
-   "DND5E.AdvancementControlDelete": "Lösche Fortschritt",
-   "DND5E.AdvancementControlDuplicate": "Dupliziere Fortschritt",
-   "DND5E.AdvancementControlEdit": "Bearbeite Fortschritt",
-   "DND5E.AdvancementCustomIcon": "Eigenes Icon",
-   "DND5E.AdvancementCustomTitle": "Eigener Titel",
-   "DND5E.AdvancementDeleteConfirmationLabel": "Änderung durch Fortschritt entfernen",
-   "DND5E.AdvancementDeleteConfirmationMessage": "Dieses Item zu entfernen, entfernt auch alle dafür getroffenen Fortschrittsentscheidungen. Diese werden vom Charakter entfernt, wenn die Checkbox unten aktiviert ist.",
-   "DND5E.AdvancementDeleteConfirmationTitle": "Entfernen bestätigen",
-   "DND5E.AdvancementFlowDropAreaHint": "Item hierhin ziehen, um es auszuwählen.",
-   "DND5E.AdvancementHint": "Hinweis",
-   "DND5E.AdvancementHitPointsAverage": "Durchschnitt nehmen",
-   "DND5E.AdvancementHitPointsEmptyError": "Trefferpunkte müssen gewählt oder der Durchschnitt genommen werden.",
-   "DND5E.AdvancementHitPointsHint": "Verfolge die Trefferpunkte des Spielers für jede Stufe in der Klasse.",
-   "DND5E.AdvancementHitPointsInvalidError": "Trefferpunkte müssen eine ganze Zahl sein.",
-   "DND5E.AdvancementHitPointsMaxAtFirstLevel": "Maximum auf Stufe 1: <strong>{max}</strong>",
-   "DND5E.AdvancementHitPointsRollButton": "Würfle {die}",
-   "DND5E.AdvancementHitPointsRollMessage": "Würfle {class} Trefferpunkte",
-   "DND5E.AdvancementHitPointsTitle": "Trefferpunkte",
-   "DND5E.AdvancementItemChoiceChosen": "Gewählt: {current} von {max}",
-   "DND5E.AdvancementItemChoiceHint": "Lässt den Spieler aus mehreren Items (wie Ausrüstung, Merkmalen oder Zaubern) auf einer oder mehreren Stufen wählen.",
-   "DND5E.AdvancementItemChoiceChoices": "Auswahlmöglichkeiten",
-   "DND5E.AdvancementItemChoiceChoose": "wähle {count}",
-   "DND5E.AdvancementItemChoiceFeatureLevelWarning": "Muss mindestens Stufe {Stufe} sein, um dieses Merkmal nutzen zu können.",
-   "DND5E.AdvancementItemChoiceLevelsHint": "Wie viele Items dürfen je Stufe gewählt werden?",
-   "DND5E.AdvancementItemChoiceNoOriginalError": "Die zuvor gewählte Auswahl kann nicht mehr ersetzt werden.",
-   "DND5E.AdvancementItemChoicePreviouslyChosenWarning": "Dises Item wurde bereits auf einer vorherigen Stufe gewählt.",
-   "DND5E.AdvancementItemChoiceReplacement": "Ersetzen möglich",
-   "DND5E.AdvancementItemChoiceReplacementNone": "Nichts ersetzen",
-   "DND5E.AdvancementItemChoiceReplacementTitle": "Ersetzen",
-   "DND5E.AdvancementItemChoiceSpellLevelAvailable": "Jeder verfügbare Grad",
-   "DND5E.AdvancementItemChoiceSpellLevelAvailableWarning": "Nur {level} oder niedrigere Zauber können für diesen Fortschritt gewählt werden.",
-   "DND5E.AdvancementItemChoiceSpellLevelHint": "Erlaubt nur die Wahl von Zaubern diesen Grades.",
-   "DND5E.AdvancementItemChoiceSpellLevelSpecificWarning": "Nur {level} Zauber können für diesen Fortschritt gewählt werden.",
-   "DND5E.AdvancementItemChoiceTitle": "Items wählen",
-   "DND5E.AdvancementItemChoiceType": "Itemtyp",
-   "DND5E.AdvancementItemChoiceTypeAny": "Alles",
-   "DND5E.AdvancementItemChoiceTypeHint": "Schränkt ein, welche Arten von Items gewählt werden können.",
-   "DND5E.AdvancementItemChoiceTypeWarning": "Nur {type}-Items können für diese Wahl gewählt werden.",
-   "DND5E.AdvancementItemGrantContainerWarning": "Der Inhalt von Behältern wird nicht zu den Behältern hinzugefügt.",
-   "DND5E.AdvancementItemGrantDropHint": "Items hierhin ziehen, um sie zu der Liste der Items hinzuzufügen, die durch diesen Fortschritt gewährt werden.",
-   "DND5E.AdvancementItemGrantDuplicateWarning": "Dieses Items existiert bereits in diesem Fortschritt.",
-   "DND5E.AdvancementItemGrantHint": "Gewährt dem Charakter Items (wie Ausrüstung, Merkmale oder Zauber), wenn er eine bestimmte Stufe erreicht.",
-   "DND5E.AdvancementItemGrantOptional": "Optional",
-   "DND5E.AdvancementItemGrantOptionalHint": "Wenn optional, erhalten Spieler die Option, jedes der folgenden Items abzulehnen, ansonsten werden alle gewährt.",
-   "DND5E.AdvancementItemGrantRecursiveWarning": "Kann kein Item gewähren, dass selbst ein Fortschritt ist.",
-   "DND5E.AdvancementItemGrantTitle": "Items gewähren",
-   "DND5E.AdvancementItemTypeInvalidWarning": "Items vom Typ {type} können nicht mit diesem Fortschrittstyp hinzugefügt werden.",
-   "DND5E.AdvancementLevelAnyHeader": "Jede Stufe",
-   "DND5E.AdvancementLevelDownConfirmationMessage": "Diese Klasse herabzustufen wird auch alle Fortschrittsentscheidungen rückgängig machen. Diese werden vom Charaktere entfernt, wenn die Checkbox unten aktiviert ist.",
-   "DND5E.AdvancementLevelDownConfirmationTitle": "Herabstufen bestätigen",
-   "DND5E.AdvancementLevelHeader": "Stufe {level}",
-   "DND5E.AdvancementLevelNoneHeader": "Keine Stufe",
-   "DND5E.AdvancementManagerCloseButtonContinue": "Weiter",
-   "DND5E.AdvancementManagerCloseButtonStop": "Fortschritt stoppen",
-   "DND5E.AdvancementManagerCloseMessage": "<p>Wenn der Fortschrittsprozess angebrochen wird, werden bisher getroffene Entscheidungen verworfen und keine Änderungen am Akteur vorgenommen.</p>",
-   "DND5E.AdvancementManagerCloseTitle": "Fortschritt stoppen",
-   "DND5E.AdvancementManagerComplete": "Fertig",
-   "DND5E.AdvancementManagerLevelIncreasedTitle": "Charakter-Stufenaufstieg",
-   "DND5E.AdvancementManagerLevelNewClassTitle": "Klasse hinzufügen",
-   "DND5E.AdvancementManagerModifyChoicesTitle": "Auswahl ändern",
-   "DND5E.AdvancementManagerNextStep": "Nächste",
-   "DND5E.AdvancementManagerPreviousStep": "Vorherige",
-   "DND5E.AdvancementManagerRestart": "Reset",
-   "DND5E.AdvancementManagerRestartConfirm": "Alle bisherigen Entscheidungen zurücksetzen?",
-   "DND5E.AdvancementManagerRestartConfirmTitle": "Fortschrittsentscheidungen neu starten",
-   "DND5E.AdvancementManagerSteps": "Schritt {current} von {total}",
-   "DND5E.AdvancementManagerTitle": "Fortschritt",
-   "DND5E.AdvancementMigrationConfirm": "Migrationen anwenden",
-   "DND5E.AdvancementMigrationHint": "Wählen, welche der folgenden Fortschritte {name} hinzugefügt werden.",
-   "DND5E.AdvancementMigrationTitle": "Fortschritte migrieren",
-   "DND5E.AdvancementModifyChoices": "Auswahl ändern",
-   "DND5E.AdvancementSaveButton": "Fortschritt speichern",
-   "DND5E.AdvancementScaleValueHint": "Ein einzelner Wert, der sich mit dem Stufenfortschritt der Klasse verändert und in Würfelformeln zur Verfügung steht (z.B. wie der Kampfkünstewürfel des Mönchs).",
-   "DND5E.AdvancementScaleValueIdentifierHint": "Dieser skalierende Wert kann für die aktuelle Stufe mit <strong>@scale.{class}.{identifier}</strong> in einer Formel eingesetzt werden.",
-   "DND5E.AdvancementScaleValueTitle": "Skalierender Wert",
-   "DND5E.AdvancementScaleValueTypeCR": "Herausforderungsgrad",
-   "DND5E.AdvancementScaleValueTypeDice": "Würfel",
-   "DND5E.AdvancementScaleValueTypeDistance": "Distanz",
-   "DND5E.AdvancementScaleValueTypeHintCR": "Diesen Typ für Herausforderungsgrade nutzen, z.B. für Merkmale wie Tiergestalt.",
-   "DND5E.AdvancementScaleValueTypeHintDice": "Diesen Typ für Würfelwerte nutzen, wie z.B. den Bonusschaden durch hinterhältige Angriffe oder Bardische Inspiration.",
-   "DND5E.AdvancementScaleValueTypeHintDistance": "Diesen Wert für numerische Werte nutzen, die eine Distanz repräsentieren, z.B. Ungerüstete Bewegung oder den Radius der Aura des Schutzes.",
-   "DND5E.AdvancementScaleValueTypeHintNumber": "Diesen Typ für rein numerische Werte nutzen, wie z.B. die Anzahl Nutzungen am Tag oder den Schadensbonus vom Kampfrausch.",
-   "DND5E.AdvancementScaleValueTypeHintString": "Diesen Typ nutzen, wenn der Typ des Werts unbekannt oder unwichtig ist.",
-   "DND5E.AdvancementScaleValueTypeLabel": "Typ",
-   "DND5E.AdvancementScaleValueTypeNumber": "Numerisch",
-   "DND5E.AdvancementScaleValueTypeString": "Beliebig",
-   "DND5E.AdvancementSelectionCreateButton": "Fortschritt erstellen",
-   "DND5E.AdvancementSelectionTitle": "Fortschrittstyp wählen",
-   "DND5E.AdvancementSizeFlowHintSingle": "Deine Größe ist {size}.",
-   "DND5E.AdvancementSizeHint": "Legt die Größe eines Charakters fest.",
-   "DND5E.AdvancementSizeTitle": "Größe",
-   "DND5E.AdvancementSizeflowHintMultiple": "Wähle deine Größe zwischen {sizes}.",
-   "DND5E.AdvancementTitle": "Fortschritt",
-   "DND5E.AdvancementTraitActionAddChoice": "Auswahl hinzufügen",
-   "DND5E.AdvancementTraitActionRemoveChoice": "Auswahl entfernen",
-   "DND5E.AdvancementTraitAllowReplacements": "Ersatz erlauben",
-   "DND5E.AdvancementTraitAllowReplacementsHint": "Wenn ein Merkmal bereits auf dem Akteur vorhanden ist, kann der Spieler ein beliebiges anderes Merkmal als Ersatz wählen.",
-   "DND5E.AdvancementTraitChoices": "Auswahl",
-   "DND5E.AdvancementTraitChoicesHint": "Die folgenden Merkmale werden dem Spieler zur Auswahl gestellt.",
-   "DND5E.AdvancementTraitChoicesRemaining": "Wähle {count} weitere {type}",
-   "DND5E.AdvancementTraitCount": "Anzahl",
-   "DND5E.AdvancementTraitGrants": "Garantiert",
-   "DND5E.AdvancementTraitGrantsHint": "Die folgenden Merkmale werden dem Charakter verliehen, sofern dieser nicht bereits über dieses Merkmal verfügt.",
-   "DND5E.AdvancementTraitHint": "Gewährt einem Charakter bestimmte Merkmale oder die Möglichkeit Merkmale auszuwählen (z.B. Übungen, Fertigkeiten, Sprachen).",
-   "DND5E.AdvancementTraitMode": "Modus",
-   "DND5E.AdvancementTraitModeDefaultHint": "Gewährt ein Merkmal oder eine Übung",
-   "DND5E.AdvancementTraitModeDefaultLabel": "Standard",
-   "DND5E.AdvancementTraitModeExpertiseHint": "Gewährt Expertise in einer Fertigkeit in der du bereits geübt bist.",
-   "DND5E.AdvancementTraitModeExpertiseLabel": "Expertise",
-   "DND5E.AdvancementTraitModeForceHint": "Gewährt Expertise in einer Fertigkeit unabhängig von der Übung.",
-   "DND5E.AdvancementTraitModeForceLabel": "Erzwungene Expertise",
-   "DND5E.AdvancementTraitModeMasteryLabel": "Meisterschaft",
-   "DND5E.AdvancementTraitModeMasteryHint": "Erhalte Meisterschaft mit einer Waffe mit der du bereits geübt bist.",
-   "DND5E.AdvancementTraitModeUpgradeHint": "Gewährt Übung in einer Fertigkeit, es sei denn, du hast diese bereits, gewährt dann Expertise.",
-   "DND5E.AdvancementTraitModeUpgradeLabel": "Upgrade",
-   "DND5E.AdvancementTraitTitle": "Merkmale",
-   "DND5E.AdvancementTraitType": "Merkmal Typ",
-   "DND5E.Advantage": "Vorteil",
-   "DND5E.AdvantageMode": "Vorteilmodus",
-   "DND5E.Age": "Alter",
-   "DND5E.Alignment": "Gesinnung",
-   "DND5E.AlignmentCE": "Chaotisch Böse",
-   "DND5E.AlignmentCG": "Chaotisch Gut",
-   "DND5E.AlignmentCN": "Chaotisch Neutral",
-   "DND5E.AlignmentLE": "Rechtschaffen Böse",
-   "DND5E.AlignmentLG": "Rechtschaffen Gut",
-   "DND5E.AlignmentLN": "Rechtschaffen Neutral",
-   "DND5E.AlignmentNE": "Neutral Böse",
-   "DND5E.AlignmentNG": "Neutral Gut",
-   "DND5E.AlignmentTN": "Neutral",
-   "DND5E.Amount": "Anzahl",
-   "DND5E.Appearance": "Erscheinung",
-   "DND5E.Apply": "Anwenden",
-   "DND5E.AreaOfEffect": "Wirkungsbereich",
-   "DND5E.Armor": "Rüstung",
-   "DND5E.ArmorClass": "Rüstungsklasse",
-   "DND5E.ArmorClassCalculation": "Berechnung",
-   "DND5E.ArmorClassCustom": "Eigene Formel",
-   "DND5E.ArmorClassDraconic": "Drakonische Widerstandskraft",
-   "DND5E.ArmorClassEquipment": "Angelegte Rüstung",
-   "DND5E.ArmorClassFlat": "Pauschal",
-   "DND5E.ArmorClassFormula": "Formel",
-   "DND5E.ArmorClassMage": "Magierrüstung",
-   "DND5E.ArmorClassMotionless": "Bewegunglose Rüstungsklasse",
-   "DND5E.ArmorClassNatural": "Natürliche Rüstung",
-   "DND5E.ArmorClassUnarmored": "Ungerüstet",
-   "DND5E.ArmorClassUnarmoredBarbarian": "Ungerüstete Verteidigung (Barbar)",
-   "DND5E.ArmorClassUnarmoredBard": "Ungerüstete Verteidigung (Barde)",
-   "DND5E.ArmorClassUnarmoredMonk": "Ungerüstete Verteidigung (Mönch)",
-   "DND5E.ArmorConfig": "Rüstung bearbeiten",
-   "DND5E.ArmorConfigHint": "Feld oben ausfüllen, um die automatisch berechnete Rüstungsklasse zu überschreiben.",
-   "DND5E.ArmorHeavyProficiency": "Schwer",
-   "DND5E.ArmorLightProficiency": "Leicht",
-   "DND5E.ArmorMediumProficiency": "Mittel",
-   "DND5E.Attack": "Angriff",
-   "DND5E.AttackPl": "Angriffe",
-   "DND5E.AttackRoll": "Angriffswurf",
-   "DND5E.AttrConcentration": {
-       "Limit": "Limit"
-   },
-   "DND5E.Attributes": "Attribute",
-   "DND5E.Attuned": "Eingestimmt",
-   "DND5E.Attunement": "Einstimmung",
-   "DND5E.AttunementAttuned": "Eingestimmt",
-   "DND5E.AttunementMax": "Maximal Eingestimmte Gegenstände",
-   "DND5E.AttunementNone": "Einstimmung nicht nötig",
-   "DND5E.AttunementOptional": "Einstimmung optional",
-   "DND5E.AttunementOverride": "Einstimmung überschreiben",
-   "DND5E.AttunementRequired": "Einstimmung nötig",
-   "DND5E.Automatic": "Automatisch",
-   "DND5E.AutomaticValue": "Automatisch ({value})",
-   "DND5E.Award": {
-       "Title": "Belohnung verteilen",
-       "Action": "Belohnung",
-       "Distribution": {
-           "Split": "Aufteilen",
-           "Each": "Jeder"
-       },
-       "Message": "{name} has been awarded {award}.",
-       "NoDestinations": "Kein Ziel verfügbar",
-       "NoPrimaryParty": "Keine primäre Gruppe festgelegt, zeigt stattdessen die den Spielern zugewiesenen Charaktere.",
-       "NotGMError": "Der /award Befehl ist nur für SL verfügbar.",
-       "UnrecognizedWarning": "Kann {commands} nicht parsen. Der Befehl /award sollte mit XP und Währungen verwendet werden wie '/award 10gp 50xp'"
-   },
-   "DND5E.Background": "Hintergrund",
-   "DND5E.BackgroundAdd": "Hintergrund hinzufügen",
-   "DND5E.BackgroundName": "Hintergrundname",
-   "DND5E.Biography": "Biographie",
-   "DND5E.BiographyPublic": "Öffentliche Biographie",
-   "DND5E.BiopgrahyPublicEdit": "Bearbeite Öffentliche Biographie",
-   "DND5E.Bonds": "Bindungen",
-   "DND5E.Bonus": "Bonus",
-   "DND5E.BonusAbility": "Globaler Attributsbonus",
-   "DND5E.BonusAbilityCheck": "Genereller Bonus auf Attributswürfe",
-   "DND5E.BonusAbilitySave": "Genereller Bonus auf Rettungswürfe",
-   "DND5E.BonusAbilitySaveTitle": "Generelle Rettungswürfe",
-   "DND5E.BonusAbilitySkill": "Genereller Bonus auf Fertigkeiten",
-   "DND5E.BonusAction": "Bonusaktion",
-   "DND5E.BonusActionAbbr": "BA",
-   "DND5E.BonusAttack": "Angriffsbonus",
-   "DND5E.BonusDamage": "Schadensbonus",
-   "DND5E.BonusMSAttack": "Nahkampf-Zauberangriffs Bonus",
-   "DND5E.BonusMSDamage": "Nahkampf-Zauberangriff Schadens Bonus",
-   "DND5E.BonusMWAttack": "Nahkampf-Waffenangriffs Bonus",
-   "DND5E.BonusMWDamage": "Nahkampf-Waffenangriff Schadens Bonus",
-   "DND5E.BonusRSAttack": "Fernkampf-Zauberangriffs Bonus",
-   "DND5E.BonusRSDamage": "Fernkampf-Zauberangriff Schadens Bonus",
-   "DND5E.BonusRWAttack": "Fernkampf-Waffenangriffs Bonus",
-   "DND5E.BonusRWDamage": "Fernkampf-Waffenangriff Schadens Bonus",
-   "DND5E.BonusSaveForm": "Aktualisierter Bonus",
-   "DND5E.BonusSpell": "Globale Zauberboni",
-   "DND5E.BonusSpellDC": "Genereller Zauber SG Bonus",
-   "DND5E.BonusTitle": "Bearbeite Spielercharakter-Boni",
-   "DND5E.Bonuses": "Generelle Boni",
-   "DND5E.BonusesHint": "Definiere generelle Boni als Formeln, die zu bestimmten Würfen hinzugefügt werden. Zum Beispiel: 1d4 + 2",
-   "DND5E.BonusesInstructions": "Bearbeite Charakter-Boni, die dem entsprechenden Würfelwurf hinzugefügt werden",
-   "DND5E.Casting": "Wirken",
-   "DND5E.ChallengeRating": "Herausforderungsgrad",
-   "DND5E.Charged": "Aufladen",
-   "DND5E.Charges": "Ladungen",
-   "DND5E.ChatContextDamage": "Schaden verursachen",
-   "DND5E.ChatContextDoubleDamage": "Verursacht doppelten Schaden",
-   "DND5E.ChatContextHalfDamage": "Verursacht halben Schaden",
-   "DND5E.ChatContextSelectHit": "Wähle getroffene Ziele",
-   "DND5E.ChatContextSelectMiss": "Wähle verfehlte Ziele",
-   "DND5E.ChatContextHealing": "Heilung anwenden",
-   "DND5E.ChatContextTempHP": "Temporäre TP anwenden",
-   "DND5E.ChatFlavor": "Chatnachrichten-Flavortext",
-   "DND5E.CHECK": {
-       "Title": "Probe",
-       "FIELDS": {
-           "check": {
-               "label": "Proben-Details",
-               "ability": {
-                   "label": "Proben Attribut",
-                   "hint": "Attribut das für die Probe genutzt wird."
-               },
-               "associated": {
-                   "label": "Assoziierte Fertigkeiten oder Werkzeuge",
-                   "hint": "Führe die Attributsproben anhand Übung und Boni mit diesen Fertigkeiten und Werkzeugen durch."
-               },
-               "dc": {
-                   "label": "Schwierigkeitsgrad",
-                   "calculation": {
-                       "label": "SG Berechnung",
-                       "hint": "Methode oder Attribut, das zur Berechnung des Schwierigkeitsgrades verwendet wird."
-                   },
-                   "formula": {
-                       "label": "SG Formel",
-                       "hint": "Eigene Formel oder fester Wert zur Definition des Proben-SG."
-                   }
-               }
-           }
-       },
-       "ThisTool": "Dieses Werkzeug"
-   },
-   "DND5E.CheckBonus": "Probenbonus",
-   "DND5E.CLASS": {
-       "Multiclass": {
-           "Title": "Klassenkombinationen"
-       },
-       "FIELDS": {
-           "hitDice": {
-               "label": "Trefferwürfel"
-           },
-           "hitDiceUsed": {
-               "label": "Verbrauchte Trefferwürfel"
-           },
-           "levels": {
-               "label": "Klassenstufe"
-           },
-           "primaryAbility": {
-               "all": {
-                   "label": "Benötigt Alle",
-                   "hint": "Benötige alle primären Attribute auf dem Minimum, um mehrere Klassen zu spielen."
-               },
-               "value": {
-                   "label": "Primärattribut",
-                   "hint": "Attribute, die von dieser Klasse am häufigsten verwendet werden. Dient zur Bestimmung der Voraussetzung für Klassenkombinationen."
-               }
-           }
-       }
-   }, 
-   "DND5E.ClassAdd": "Klasse hinzufügen",
-   "DND5E.ClassIdentifier": "Klassen-ID",
-   "DND5E.ClassIdentifierHint": "Die Daten dieser Klasse werden unter der ID <strong>@classes.{identifier}</strong> in Formeln verfügbar sein.",
-   "DND5E.ClassLevels": "Klassenstufen",
-   "DND5E.ClassMakeOriginal": "Ursprungsklasse",
-   "DND5E.ClassMakeOriginalHint": "Erste Klasse, die von einem Charakter gewählt wurde. Wird genutzt, um manche Klasseneigenschaften bei Klassenkombinationen zu bestimmen.",
-   "DND5E.ClassName": "Klassenname",
-   "DND5E.ClassOriginal": "Ursprungsklasse",
-   "DND5E.ClassSaves": "Rettungswürfe",
-   "DND5E.Confirm": "Bestätigen",
-   "DND5E.CompendiumBrowser": {
-       "Title": "Kompendium Browser",
-       "Action": {
-           "Open": "Kompendium Browser öffnen"
-       },
-       "Column": {
-           "Icon": "Icon",
-           "Name": "Name",
-           "Results": "Ergebnisse",
-           "Source": "Quelle"
-       },
-       "Filters": {
-           "Label": "Filter",
-           "HasDarkvision": "Hat Dunkelsicht",
-           "HasSpellcasting": "Hat Zauberwirken",
-           "SearchResults": "Ergebnisse Durchsuchen"
-       },
-       "Selection": {
-           "Label": "Ausgewählt: {summary}",
-           "Select": "Auswählen",
-           "Summary": {
-               "Max": "<span class=\"value\">{value}</span> von bis zu {max}",
-               "Min": "<span class=\"value\">{value}</span> von mindestens {min}",
-               "Range": "<span class=\"value\">{value}</span> von {min} bis {max}",
-               "Single": "<span class=\"value\">{value}</span> von {max}"
-           },
-           "Warning": {
-               "Document": {
-                   "one": "Dokument",
-                   "other": "Dokumente"
-               },
-               "Max": "Muss maximal {max} {document} auswählen, {value} ausgewählt.",
-               "Min": "Muss mindestens {min} {document} auswählen, {value} ausgewählt.",
-               "Range": "Muss zwischen {min} und {max} {document} auswählen, {value} ausgewählt.",
-               "Single": "Muss {max} {document} auswählen, {value} ausgewählt."
-           }
-       },
-       "Tabs": {
-           "Feat.other": "Merkmale",
-           "Item.other": "Items",
-           "Monster.other": "Monster"
-       },
-       "Types": {
-           "Label": "Typen"
-       },
-       "Locked": "Gesperrt",
-       "Sources": {
-       "Name": "Compendium Browser Quellen",
-           "Label": "Konfiguriere Quellen",
-           "FilterPackages": "Pakete Filtern",
-           "Hint": "Konfiguriere, welche Kompendienpakete im Kompendium Browser verfügbar sind."
-       }
-   },
-   "DND5E.ComponentMaterial": "Material",
-   "DND5E.ComponentMaterialAbbr": "M",
-   "DND5E.ComponentSomatic": "Gesten",
-   "DND5E.ComponentSomaticAbbr": "G",
-   "DND5E.ComponentVerbal": "Verbal",
-   "DND5E.ComponentVerbalAbbr": "V",
-   "DND5E.Components": "Komponenten",
-   "DND5E.ConBlinded": "Blind",
-   "DND5E.ConCharmed": "Bezaubert",
-   "DND5E.ConDeafened": "Taub",
-   "DND5E.ConDiseased": "Erkrankt",
-   "DND5E.ConExhaustion": "Erschöpft",
-   "DND5E.ConFrightened": "Verängstigt",
-   "DND5E.ConGrappled": "Gepackt",
-   "DND5E.ConImm": "Zustandsimmunitäten",
-   "DND5E.ConIncapacitated": "Kampfunfähig",
-   "DND5E.ConInvisible": "Unsichtbar",
-   "DND5E.ConParalyzed": "Gelähmt",
-   "DND5E.ConPetrified": "Versteinert",
-   "DND5E.ConPoisoned": "Vergiftet",
-   "DND5E.ConProne": "Liegend",
-   "DND5E.ConRestrained": "Festgesetzt",
-   "DND5E.ConStunned": "Betäubt",
-   "DND5E.ConUnconscious": "Bewusstlos",
-   "DND5E.Concentration": "Konzentration",
-   "DND5E.ConcentrationAbbr": "K",
-   "DND5E.ConcentrationBreak": "Breche Konzentration",
-   "DND5E.ConcentrationBreakWarning": "Das Brechen der Konzentration auf einen Effekt, der bei anderen Kreaturen aktiv ist, erfordert die Anwesenheit eines aktiven SL.",
-   "DND5E.ConcentrationBonus": "Konzentrationsbonus",
-   "DND5E.ConcentrationDuration": "Konzentration, bis zu {duration}",
-   "DND5E.ConcentratingOn": "Du hältst die Konzentration auf die Effekte von '{Name}' {Typ} aufrecht.",
-   "DND5E.ConcentratingEndChoice": "Du konzentrierst dich auf Effekte aus mehr als einer Quelle. Wählen Sie aus, welche Effekte Sie beenden wollen.",
-   "DND5E.ConcentratingMissingItem": "Die Effekte, auf die man sich konzentriert und die ersetzt werden sollen, gibt es nicht.",
-   "DND5E.ConcentratingLimited": "Du bist nicht in der Lage, dich auf einen zusätzlichen Effekt zu konzentrieren.",
-   "DND5E.ConcentrationLimit": "Konzentrationsgrenze",
-   "DND5E.ConcentratingEnd": "Konzentration beenden",
-   "DND5E.ConcentratingItemless": "Konzentration ohne Quelle",
-   "DND5E.ConcentratingWarnLimit": "Sie können sich nicht auf mehrere Effekte konzentrieren!",
-   "DND5E.ConcentratingWarnLimitOptional": "Du kannst die Konzentration auf einen deiner aufrechterhaltenen Effekte beenden, um diesen Gegenstand zu benutzen.",
-   "DND5E.ConcentratingWarnLimitZero": "Du bist nicht in der Lage, dich auf irgendwelche Effekte zu konzentrieren!",
-   "DND5E.ConcentrationConfigurationHint": "Konfiguriere die Konzentrationsmodifikatoren und -boni, die für diese Kreatur gelten.",
-   "DND5E.Conditions": "Zustände",
-   "DND5E.Controls": {
-       "Hint": "Aktivieren Sie verschiedene Hinweise auf der Benutzeroberfläche für bestimmte Maus- und Tastatursteuerungen.",
-       "LockHint": "Mittlere Maustaste zum sperren",
-       "MiddleClick": "Mittlere Maustaste",
-       "Name": "Aktiviere Steuerungshinweise",
-       "LeftClick": "Links Klick",
-       "Activity": {
-           "FastForwardHint": "<kbd>Shift</kbd> + <left-click> das Item, um diesen Dialog zu überspringen"
-       }
-   },
-   "DND5E.ConsumableLastChargeWarn": "Dies ist die letzte Ladung, und wenn sie verbraucht wird, verringert sich auch die Menge des Items um 1",
-   "DND5E.ConsumableUnitWarn": "verbleibende Ladungen",
-   "DND5E.ConsumableUseWarnEnd": "der aktuellen Ladungen",
-   "DND5E.ConsumableUseWarnStart": "dieses Verbrauchsmaterial hat",
-   "DND5E.ConsumableWithoutCharges": "verfügbare und verwendbare Ladungen",
-   "DND5E.CONSUMPTION": {
-       "FIELDS": {
-           "consumption": {
-               "label": "Verbrauch",
-               "scaling": {
-                   "abbr": "Skalierung",
-                   "label": "Verbrauch Skalieren",
-                   "allowed": {
-                       "label": "Skalierung Erlauben",
-                       "hint": "Kann eine Aktivität, die nicht in einem Zauber enthalten ist, auf höheren Stufen aktiviert werden?"
-                   },
-                   "max": {
-                       "label": "Maximale Skalierung",
-                       "hint": "Maximale Anzahl von Skalierungsebenen für dieses Item, einschließlich der Basisstufe."
-                   }
-               },
-               "spellSlot": {
-                   "label": "Verbrauche Zauberplatz",
-                   "hint": "Soll die Verwendung dieser Aktivität einen Zauberplatz für diesen Zauber verbrauchen?"
-               },
-               "targets": {
-                   "label": "Verbrauchsziele",
-                   "hint": "Ziele des möglichen Verbrauchs, wenn diese Aktivität aktiviert wird.",
-                   "FIELDS": {
-                       "type": {
-                           "label": "Verbrauchstyp",
-                           "hint": "Art des Verbrauchsziels."
-                       },
-                       "target": {
-                           "label": "Verbrauchsziel",
-                           "hint": "Spezifisches Ziel das verbraucht werden soll."
-                       },
-                       "value": {
-                           "label": "Verbrauchsmenge",
-                           "hint": "Gib einen negativen Wert ein, um wiederherzustellen, statt zu verbrauchen."
-                       },
-                       "scaling": {
-                           "label": "Verbrauchsskalierung",
-                           "mode": {
-                               "label": "Skalierungsmodus",
-                               "hint": "Wie der Verbrauch skaliert werden sollte."
-                           },
-                           "formula": {
-                               "label": "Skalierungsformel",
-                               "hint": "Individuelle Skalierung der Verbrauchsmenge pro Stufe."
-                           }
-                       }
-                   }
-               }
-           }
-       },
-       "Action": {
-           "ConsumeResource": "Ressource verbrauchen",
-           "Create": "Verbrauchsziel erstellen",
-           "Delete": "Verbrauchsziel entfernen",
-           "RefundResource": "Ressource Zurückerstatten"
-       },
-       "Scaling": {
-           "Amount": "Anzahl",
-           "Automatic": "Automatisch",
-           "None": "Keine Skalierung",
-           "SlotLevel": "Zauberplatzgrad"
-       },
-       "Target": {
-           "ThisItem": "Dieses Item"
-       },
-       "Type": {
-           "ActivityUses": {
-               "Label": "Aktivität Nutzungen",
-               "PromptDecrease": "Aktivität Nutzung Verbrauchen?",
-               "PromptIncrease": "Aktivität Nutzung Wiederherstellen?",
-               "PromptHintDecrease": "Gib <strong>{cost}</strong> {use} von dieser Aktivität.",
-               "PromptHintIncrease": "Erhalte <strong>{cost}</strong> {use} für diese Aktivität.",
-               "Warning": "Nutzungen von {item} Aktivität {activity}"
-           },
-           "Attribute": {
-               "Label": "Attribut",
-               "PromptDecrease": "Attribut Verbrauchen?",
-               "PromptIncrease": "Attribut Wiederherstellen?",
-               "PromptHintDecrease": "Verringere <code>{attribute}</code> um <strong>{cost}</strong>.",
-               "PromptHintIncrease": "Erhöhe <code>{attribute}</code> um <strong>{cost}</strong>.",
-               "Warning": "{attribute} Anzahl"
-           },
-           "HitDice": {
-               "Label": "Tefferwürfel",
-               "PromptDecrease": "Trefferwürfel Verbrauchen?",
-               "PromptIncrease": "Trefferwürfel Wiederherstellen?",
-               "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {denomination} {die}.",
-               "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {denomination} {die}.",
-               "Warning": "{denomination} Trefferwürfel"
-           },
-           "HitDie": {
-               "one": "Trefferwürfel",
-               "other": "Trefferwürfel"
-           },
-           "ItemUses": {
-               "Label": "Itemnutzungen",
-               "PromptDecrease": "Itemnutzung Verbrauchen?",
-               "PromptIncrease": "Itemnutzung Wiederherstellen?",
-               "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {use} von {item}.",
-               "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {use} von {item}.",
-               "Warning": "Nutzungen von {name}"
-           },
-           "Material": {
-               "Label": "Material",
-               "PromptDecrease": "Material Verbrauchen?",
-               "PromptIncrease": "Material Wiederherstellen?",
-               "PromptHintDecrease": "Verringere Anzahl von {item} um <strong>{cost}</strong>.",
-               "PromptHintIncrease": "Erhöhe Anzahl von {item} um <strong>{cost}</strong>.",
-               "Warning": "Von {name}"
-           },
-           "SpellSlot": {
-               "one": "{level}. Grad",
-               "other": "{level}. Grade"
-           },
-           "SpellSlots": {
-               "Label": "Zauberplätze",
-               "PromptDecrease": "Zauberplatz verbrauchen?",
-               "PromptIncrease": "Zauberplatz wiederherstellen?",
-               "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {slot}.",
-               "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {slot}.",
-               "Warning": "{level}. Grad"
-           },
-           "Use": {
-               "one": "Nutzung",
-               "other": "Nutzungen"
-           }
-       },
-       "Warning": {
-           "MissingAttribute": "Das Attribut {attribute}, das für die Verwendung durch die {activity} Aktivität auf dem {item} konfiguriert wurde, konnte nicht gefunden werden.",
-           "MissingHitDice": "Der Akteur hat keine Klasse mit einem {denomination} Trefferwürfel",
-           "MissingItem": "Das Item, das für den Verbrauch durch die {activity} Aktivität auf {item} konfiguriert wurde, konnte nicht gefunden werden.",
-           "MissingSpellSlot": "Keine {level}. Grad Plätze verfügbar.",
-           "None": "Kein {type} verfügbar zum verbrauchen, {cost} benötigt",
-           "NotEnough": "Nicht genug {type} verfügbar zum verbrauchen, {cost} benötigt und nur {available} verfügbar."
-       }
-   },
-   "DND5E.ConsumeAmmunition": "Munition",
-   "DND5E.ConsumeAmount": "Verbrauchsmenge",
-   "DND5E.ConsumeHint": {
-       "Attribute": "Attribute zum verbrauchen (z.B. currency.gp)",
-       "Item": "UUID des Ziels im Kompendium"
-   },
-   "DND5E.ConsumeAttribute": "Attribute",
-   "DND5E.ConsumeCharges": "Lad. Gegenst.",
-   "DND5E.ConsumeHitDice": "Trefferwürfel",
-   "DND5E.ConsumeHitDiceLargest": "Größter verfügbarer",
-   "DND5E.ConsumeHitDiceLargestLong": "Größter verfügbarer Trefferwürfel",
-   "DND5E.ConsumeHitDiceSmallest": "Kleinster verfügbarer",
-   "DND5E.ConsumeHitDiceSmallestLong": "Kleinster verfügbarer Trefferwürfel",
-   "DND5E.ConsumeMaterial": "Material",
-   "DND5E.ConsumeRecharge": "Ladung verbrauchen?",
-   "DND5E.ConsumeResource": "Ressource verbrauchen?",
-   "DND5E.ConsumeScaling": "Ressourcen Skalierung",
-   "DND5E.ConsumeScalingLabel": "Use Resources",
-   "DND5E.ConsumeScalingTooltip": "Wenn diese Option angekreuzt ist, erhöht der Verbrauch zusätzlicher Ressourcen die Stufe, auf der der Zauber gewirkt wird.",
-   "DND5E.CONSUMABLE": {
-       "FIELDS": {
-           "damage": {
-               "label": "Munitionsschaden",
-               "replace": {
-                   "label": "Ersetze Waffenschaden",
-                   "hint": "Ersetze den Basis-Waffenschaden mit diesem Schaden anstatt ihn zu erhöhen."
-               }
-           },
-           "magicalBonus": {
-               "label": "Magischer Bonus"
-           },
-           "properties": {
-               "label": "Verbrauchsgut Eigenschaften"
-           },
-           "uses": {
-               "autoDestroy": {
-                   "label": "Zerstöre wenn Leer",
-                   "hint": "Reduziere die Menge des Items um 1, wenn alle Limitierten Nutzungen aufgebraucht sind."
-               }
-           }
-       },
-       "Category": {
-           "Poison": "Gift"
-       },
-       "Type": {
-           "Ammunition": {
-               "Label": "Munition",
-               "Arrow": "Pfeil",
-               "Bolt": "Bolzen",
-               "BulletFirearm": "Kugel, Feuerwaffe",
-               "BulletSling": "Kugel, Schleuder",
-               "Needle": "Nadel"
-           },
-           "Food": {
-               "Label": "Nahrung"
-           },
-           "Poison": {
-               "Label": "Gift",
-               "Contact": "Kontakt",
-               "Ingested": "Einnahme",
-               "Inhaled": "Eingeatmet",
-               "Injury": "Verletzung"
-           },
-           "Potion": {
-               "Label": "Trank"
-           },
-           "Rod": {
-               "Label": "Rute"
-           },
-           "Scroll": {
-               "Label": "Schriftrolle"
-           },
-           "Trinket": {
-               "Label": "Schmuckstück"
-           },
-           "Wand": {
-               "Label": "Zauberstab"
-           }
-       }
-   },
-   "DND5E.ConsumeTarget": "Verbrauchsziel",
-   "DND5E.ConsumeTitle": "Ressourcen-Verbrauch",
-   "DND5E.ConsumeType": "Verbrauchstyp",
-   "DND5E.Consumed": "Verbraucht",
-   "DND5E.Copy": "Text kopieren",
-   "DND5E.Copied": "{value} kopiert",
-   "DND5E.Container": "Behälter",
-   "DND5E.ContainerDeleteContents": "Alle Items aus dem Behälter löschen.",
-   "DND5E.ContainerDeleteMessage": "Dieser Behälter wird dauerhaft gelöscht und kann nicht wiederhergestellt werden, und die darin enthaltenen {count} Items werden ausgelagert.",
-   "DND5E.ContainerMaxDepth": "Behälter können nicht mehr als {depth} Ebenen tief verschachtelt werden.",
-   "DND5E.ContainerRecursiveError": "Behälter können sich nicht selbst enthalten.",
-   "DND5E.Contents": "Inhalte",
-   "DND5E.ContextMenuActionAttune": "Einstimmen",
-   "DND5E.ContextMenuActionDelete": "Löschen",
-   "DND5E.ContextMenuActionDisable": "Deaktivieren",
-   "DND5E.ContextMenuActionDuplicate": "Duplizieren",
-   "DND5E.ContextMenuActionEdit": "Bearbeiten",
-   "DND5E.ContextMenuActionEnable": "Aktivieren",
-   "DND5E.ContextMenuActionEquip": "Ausrüsten",
-   "DND5E.ContextMenuActionPrepare": "Vorbereiten",
-   "DND5E.ContextMenuActionExpendCharge": "Entladen",
-   "DND5E.ContextMenuActionCharge": "Aufladen",
-   "DND5E.ContextMenuActionUnattune": "Einstimmung brechen",
-   "DND5E.ContextMenuActionUnequip": "Ablegen",
-   "DND5E.ContextMenuActionUnprepare": "Vorbereitung aufheben",
-   "DND5E.ContextMenuActionView": "Anzeigen",
-   "DND5E.Contiguous": "Angrenzend",
-   "DND5E.CostGP": "Kosten (GM)",
-   "DND5E.Cover": "Deckung",
-   "DND5E.CoverHalf": "Halbe",
-   "DND5E.CoverThreeQuarters": "Dreiviertel",
-   "DND5E.CoverTotal": "Volle",
-   "DND5E.Cost": "Kosten",
-   "DND5E.CreatureAberration": "Aberration",
-   "DND5E.CreatureAberrationPl": "Aberrationen",
-   "DND5E.CreatureBeast": "Tier",
-   "DND5E.CreatureBeastPl": "Tiere",
-   "DND5E.CreatureCelestial": "Himmlisches Wesen",
-   "DND5E.CreatureCelestialPl": "Himmlische Wesen",
-   "DND5E.CreatureConstruct": "Konstrukt",
-   "DND5E.CreatureConstructPl": "Konstrukte",
-   "DND5E.CreatureDragon": "Drache",
-   "DND5E.CreatureDragonPl": "Drachen",
-   "DND5E.CreatureElemental": "Elementar",
-   "DND5E.CreatureElementalPl": "Elementare",
-   "DND5E.CreatureFey": "Feenwesen",
-   "DND5E.CreatureFeyPl": "Feenwesen",
-   "DND5E.CreatureFiend": "Unhold",
-   "DND5E.CreatureFiendPl": "Unholde",
-   "DND5E.CreatureGiant": "Riese",
-   "DND5E.CreatureGiantPl": "Riesen",
-   "DND5E.CreatureHumanoid": "Humanoider",
-   "DND5E.CreatureHumanoidPl": "Humanoide",
-   "DND5E.CreatureMonstrosity": "Monstrosität",
-   "DND5E.CreatureMonstrosityPl": "Monstrositäten",
-   "DND5E.CreatureOoze": "Schlick",
-   "DND5E.CreatureOozePl": "Schlicke",
-   "DND5E.CreaturePlant": "Pflanze",
-   "DND5E.CreaturePlantPl": "Pflanzen",
-   "DND5E.CreatureSwarm": "Schwarm",
-   "DND5E.CreatureSwarmPhrase": "Schwarm von {size} {type}",
-   "DND5E.CreatureSwarmSize": "Schwarmgröße",
-   "DND5E.CreatureType": "Kreaturentyp",
-   "DND5E.CreatureTypeConfig": "Kreaturentyp bearbeiten",
-   "DND5E.CreatureTypeSelectorCustom": "Eigener Typ",
-   "DND5E.CreatureTypeSelectorSubtype": "Subtyp",
-   "DND5E.CreatureTypeTitle": "Kreaturentyp bearbeiten",
-   "DND5E.CreatureUndead": "Untoter",
-   "DND5E.CreatureUndeadPl": "Untote",
-   "DND5E.Crewed": "Bemannt",
-   "DND5E.Critical": "Kritisch",
-   "DND5E.CriticalHit": "Kritischer Treffer",
-   "DND5E.Currency": "Währung",
-   "DND5E.CurrencyAbbrCP": "km",
-   "DND5E.CurrencyAbbrEP": "em",
-   "DND5E.CurrencyAbbrGP": "gm",
-   "DND5E.CurrencyAbbrPP": "pm",
-   "DND5E.CurrencyAbbrSP": "sm",
-   "DND5E.CurrencyCP": "Kupfer",
-   "DND5E.CurrencyEP": "Elektrum",
-   "DND5E.CurrencyGP": "Gold",
-   "DND5E.CurrencyManager": {
-       "Title": "Währung verwalten",
-       "Convert": {
-           "Label": "Umrechnen",
-           "Action": "Alle Währungen umrechnen",
-           "Hint": "Rechnet alle mitgeführten Währungen in den höchstmöglichen Nennwert um, um die Menge der vom Charakter mitgeführten Münzen zu reduzieren. Aber Vorsicht: Diese Aktion kann nicht rückgängig gemacht werden."
-       },
-       "Transfer": {
-           "Action": "Auswahl übertragen",
-           "All": "Alle",
-           "Half": "Hälfte",
-           "Label": "Übertragen"
-       }
-   },
-   "DND5E.Current": "Aktuell",
-   "DND5E.DAMAGE": {
-   "Title": "Schaden",
-    "FIELDS": {
-        "damage": {
-            "label": "Schaden",
-            "critical": {
-                "allow": {
-                    "label": "Erlaube Kritische Treffer",
-                    "hint": "Sollte die Kreatur kritischen Schaden verursachen können?"
-                },
-                "bonus": {
-                    "label": "Zusätzlicher Kritischer Schaden",
-                    "hint": "Zusätzlicher Schaden, der dem ersten Schadensbestandteil zugefügt wird, wenn ein kritischer Treffer erzielt wird."
-                }
-            },
-            "parts": {
-                "label": "Schadensbestandteil",
-                "hint": "Einzelne Schadensbestandteile dem Wurf hinzufügen.",
-                "FIELDS": {
-                    "bonus": {
-                        "label": "Schadensbonus",
-                        "hint": "Bonus zum Schadenswurf hinzugefügt."
-                    },
-                    "custom": {
-                        "label": "Eigene Schadensformel",
-                        "enabled": {
-                            "label": "Eigene Formel aktivieren",
-                            "hint": "Verwende eine Eigene Formel anstelle der Standardwürfel."
-                        },
-                        "formula": {
-                            "label": "Schadensformel",
-                            "hint": "Eigene Schadensformel."
-                        }
-                    },
-                    "denomination": {
-                        "label": "Würfel Nennwert",
-                        "hint": "Nennwert des zu werfenden Würfels."
-                    },
-                    "number": {
-                        "label": "Würfel Zahl",
-                        "hint": "Zahl des zu werfenden Würfels"
-                    },
-                    "scaling": {
-                        "label": "Schadensskalierung",
-                        "abbr": "Skalierung",
-                        "mode": {
-                            "label": "Skalierungsmodus",
-                            "abbr": "Modus",
-                            "hint": "Methode, mit der die Skalierungszunahme berechnet wird."
-                        },
-                        "number": {
-                            "label": "Würfelskalierung",
-                            "abbr": "Würfel",
-                            "hint": "Anzahl der Würfel, die für jede Skalierungsstufe erhöht werden. Wird auf den ersten Würfel angewendet, der in der Schadensformel gefunden wird, wenn mehr als einer vorhanden ist."
-                        },
-                        "formula": {
-                            "label": "Skalierungsformel",
-                            "hint": "Beliebige Skalierungsformel, die für jeden Skalierungsschritt multipliziert und zur ursprünglichen Formel addiert wird."
-                        }
-                    },
-                    "types": {
-                        "label": "Schadensarten",
-                        "hint": "Art des zugefügten Schadens oder mehrere zur Auswahl für den Nutzer."
-                    }
-                }
-            }
-        }
-    },
-    "Part": {
-        "Action": {
-            "Create": "Erstelle Schadensbestandteil",
-            "Delete": "Entferne Schadensbestandteil"
-        }
-    },
-    "Scaling": {
-        "Half": "Jede zweite Stufe",
-        "None": "Keine Skalierung",
-        "Whole": "Jede Stufe"
-    }
-},
-   "DND5E.CurrencyPP": "Platin",
-   "DND5E.CurrencySP": "Silber",
-   "DND5E.DamImm": "Schadensimmunitäten",
-   "DND5E.DamMod": "Schadensmodifikation",
-   "DND5E.DamRes": "Schadensresistenzen",
-   "DND5E.DamVuln": "Schadensanfälligkeiten",
-   "DND5E.Damage": "Schaden",
-   "DND5E.DamageAll": "Sämtlicher Schaden",
-   "DND5E.DamageApplication": {
-       "Change": {
-           "Modification": "{type} Modifikation",
-           "Immunity": "{type} Immunität",
-           "Resistance": "{type} Resistenz",
-           "Vulnerability": "{type} Anfälligkeit"
-       },
-       "Downgrading": "{source} runterstufen zu Resistenz",
-       "Ignoring": "Ignoriere {source}"
-   },
-   "DND5E.DamageAcid": "Säure",
-   "DND5E.DamageBludgeoning": "Wucht",
-   "DND5E.DamageCold": "Kälte",
-   "DND5E.DamageFire": "Feuer",
-   "DND5E.DamageForce": "Energie",
-   "DND5E.DamageLightning": "Blitz",
-   "DND5E.DamageModification": {
-       "Label": "Schadensmodifikation",
-       "Hint": "Formeln für die Mengen, die zu dem typisierten Schaden, der auf diesen Akteur angewendet wird, addiert werden. Negative Werte verringern den erlittenen Schaden.",
-       "BypassHint": "Diese Waffeneigenschaften umgehen die Schadensmodifikation für physischen Schaden."
-   },
-   "DND5E.DamageNecrotic": "Nekrotisch",
-   "DND5E.DamagePhysical": "Nicht-magischer physischer",
-   "DND5E.DamagePhysicalBypass": "Phys. Resistenz-Überwindungen",
-   "DND5E.DamagePhysicalBypassHint": "Diese Waffeneigenschaften ignorieren Schadensresistenzen für physischen Schaden.",
-   "DND5E.DamagePhysicalBypasses": "{damageTypes} von Angriffen, die nicht {bypassTypes} sind",
-   "DND5E.DamagePhysicalBypassesShort": "Umgangen von {type} Quellen",
-   "DND5E.DamagePiercing": "Stich",
-   "DND5E.DamagePoison": "Gift",
-   "DND5E.DamagePsychic": "Psychisch",
-   "DND5E.DamageRadiant": "Gleißend",
-   "DND5E.DamageRoll": "Schadenswurf",
-   "DND5E.DamageSlashing": "Hieb",
-   "DND5E.DamageThreshold": "Schadensgrenzwert",
-   "DND5E.DamageThunder": "Schall",
-   "DND5E.DamageType": "Schadensart",
-   "DND5E.DamageTypes": "Schadensarten",
-   "DND5E.Dawn": "Morgengrauen",
-   "DND5E.Day": "Tag",
-   "DND5E.DeathSave": "RW gg. Tod",
-   "DND5E.DeathSaveCriticalSuccess": "{name} hat den RW gg. Tod kritisch geschafft  und erhält 1 TP!",
-   "DND5E.DeathSaveFailure": "{name} hat 3 RW gg. Tod nicht geschafft und ist tot!",
-   "DND5E.DeathSaveFailureLabel": "Todesrettungswurf Fehlschlag",
-   "DND5E.DeathSaveFailureLabelN.few": "3. Todesrettungswurf Fehlschlag",
-   "DND5E.DeathSaveFailureLabelN.one": "1. Todesrettungswurf Fehlschlag",
-   "DND5E.DeathSaveFailureLabelN.two": "2. Todesrettungswurf Fehlschlage",
-   "DND5E.DeathSaveFailures": "Fehlschläge",
-   "DND5E.DeathSaveHide": "Verstecke Todesrettungswürfe",
-   "DND5E.DeathSaveRoll": "Werfe einen Todesrettungswurf",
-   "DND5E.DeathSaveShow": "Zeige Todesrettungswürfe",
-   "DND5E.DeathSaveSuccess": "{name} hat 3 RW gg. Tod geschafft und ist jetzt stabil!",
-   "DND5E.DeathSaveSuccessLabel": "Todesrettungswurf Erfolg",
-   "DND5E.DeathSaveSuccessLabelN.few": "3. Todesrettungswurf Erfolg",
-   "DND5E.DeathSaveSuccessLabelN.one": "1. Todesrettungswurf Erfolg",
-   "DND5E.DeathSaveSuccessLabelN.two": "2. Todesrettungswurf Erfolg",
-   "DND5E.DeathSaveSuccesses": "Erfolge",
-   "DND5E.DeathSaveUnnecessary": "Du musst keinen Todesrettungswurf ablegen, da du über eine positive Trefferpunktezahl oder bereits 3 Erfolge oder Misserfolge verfügst.",
-   "DND5E.DeathSavingThrow": "RW gg. Tod",
-   "DND5E.Default": "Standard",
-   "DND5E.DefaultSpecific": "Standard ({default})",
-   "DND5E.DefaultAbilityCheck": "Standard Attributswurf",
-   "DND5E.Denomination": "Nennwert",
-   "DND5E.Description": "Beschreibung",
-   "DND5E.DescriptionEdit": "Bearbeiten {description}",
-   "DND5E.DescriptionChat": "Chatbeschreibung",
-   "DND5E.DescriptionSummary": "Beschreibung (Übersicht)",
-   "DND5E.DescriptionUnidentified": "Beschreibung (Unidentifiziert)",
-   "DND5E.Details": "Details",
-   "DND5E.DetailsEdit": "Details bearbeiten",
-   "DND5E.Die": "Würfel",
-   "DND5E.Dimensions": "Abmessungen",
-   "DND5E.Disadvantage": "Nachteil",
-   "DND5E.Disclaimer": "Disclaimer",
-   "DND5E.Discord": "Discord",
-   "DND5E.DistAny": "Jede",
-   "DND5E.DistFt": "Fuß",
-   "DND5E.DistFtAbbr": "ft",
-   "DND5E.DistKm": "Kilometer",
-   "DND5E.DistKmAbbr": "km",
-   "DND5E.DistM": "Meter",
-   "DND5E.DistMAbbr": "m",
-   "DND5E.DistMi": "Meilen",
-   "DND5E.DistMiAbbr": "mi",
-   "DND5E.DistSelf": "Selbst",
-   "DND5E.DistTouch": "Berührung",
-   "DND5E.DocumentUseWarn": "Sie haben keine Erlaubnis, ein Item in diesem Dokument zu verwenden.",
-   "DND5E.DocumentViewWarn": "Sie haben keine Erlaubnis, dieses Dokument einzusehen.",
-   "DND5E.DURATION": {
-    "FIELDS": {
-        "duration": {
-            "label": "Dauer",
-            "concentration": {
-                "label": "Konzentration",
-                "hint": "Die Kreatur muss die Konzentration aktiv halten."
-            },
-            "override": {
-                "label": "Dauer überschreiben",
-                "hint": "Verwende diese Dauerwerte anstelle der Dauer des Items, wenn du diese Aktivität verwendest."
-            },
-            "special": {
-                "label": "Spezielle Dauer",
-                "hint": "Beschreibung für jede spezielle Dauer."
-            },
-            "units": {
-                "label": "Dauer Einheiten",
-                "hint": "Einheiten zur Messung der Dauer."
-            },
-            "value": {
-                "label": "Dauer Wert",
-                "hint": "Wert der Dauer in den angegebenen Einheiten, falls zutreffend."
-            }
-        }
-    }
-},
-   "DND5E.Duration": "Dauer",
-   "DND5E.DurationPermanent": "Permanent",
-   "DND5E.DurationTime": "Zeit",
-   "DND5E.DurationType": "Dauer (Typ)",
-   "DND5E.DurationUnits": "Dauer (Einheiten)",
-   "DND5E.DurationValue": "Dauer (Wert)",
-   "DND5E.Dusk": "Abenddämmerung",
-   "DND5E.Effect": "Effekt",
-   "DND5E.EffectCreate": "Effekt erstellen",
-   "DND5E.EffectDelete": "Effekt löschen",
-   "DND5E.EffectDisable": "Effekt deaktivieren",
-   "DND5E.EffectEdit": "Effekt bearbeiten",
-   "DND5E.EffectEnable": "Effekt aktivieren",
-   "DND5E.EffectInactive": "Inaktive Effekte",
-   "DND5E.EffectNew": "Neuer Effekt",
-   "DND5E.EffectType": {
-       "Inactive": "Inaktiv",
-       "Passive": "Passiv",
-       "Temporary": "Temporär",
-       "Unavailable": "Nicht verfügbar"
-   },
-   "DND5E.EffectPassive": "Passive Effekte",
-   "DND5E.EffectTemporary": "Temporäre Effekte",
-   "DND5E.EffectToggle": "Effekt umschalten",
-   "DND5E.EffectUnavailable": "Nicht verfügbare Effekte",
-   "DND5E.EffectUnavailableInfo": "Quellen-Item muss ausgerüstet oder eingestimmt sein, um diese zu aktivieren",
-   "DND5E.Effects": "Effekte",
-   "DND5E.EFFECT": {
-    "Action": {
-        "Create": "Erstelle Effekt",
-        "Delete": "Entferne Effekt",
-        "Dissociate": "Trenne Effekt"
-    },
-    "Empty": "Kein verbundener Effekt. Verwende den <i class=\"fas fa-plus\"></i> Knopf, um einen zu erstellen, oder wähle einen vorhandenen Effekt aus dem Dropdown-Menü aus.",
-    "Label": "Verbundene Effekte"
-},
-   "DND5E.EffectsApplyTokens": "Auf ausgewählte Token anwenden",
-   "DND5E.EffectApplyWarningConcentration": "Das Anwenden eines Effekts, auf den sich ein anderer Charakter konzentriert, erfordert die Erlaubnis des SLs.",
-   "DND5E.EffectApplyWarningOwnership": "Effekte können nicht auf Token angewandt werden, deren Besitzer man nicht ist.",
-   "DND5E.EffectsSearch": "Effekte durchsuchen",
-   "DND5E.ENCHANT": {
-    "Title": "Verzauberung",
-    "FIELDS": {
-        "effects": {
-            "FIELDS": {
-                "level": {
-                    "label": "Stufengrenze",
-                    "hint": "Benötigte Stufen, um diesen Zauber zu verwenden.",
-                    "max": {
-                        "label": "Maximale Stufe"
-                    },
-                    "min": {
-                        "label": "Minimale Stufe"
-                    }
-                },
-                "riders": {
-                    "label": "Angefügt",
-                    "activity": {
-                        "label": "Zusätzliche Aktivitäten",
-                        "hint": "Diese zusätzlichen Aktivitäten werden dem verzauberten Item hinzugefügt, wenn diese Verzauberung angewendet wird, und entfernt, wenn die Verzauberung entfernt wird."
-                    },
-                    "effect": {
-                        "label": "Zusätzliche Effekte",
-                        "hint": "Diese zusätzlichen Effekte werden dem verzauberten Item hinzugefügt, wenn diese Verzauberung angewendet wird, und entfernt, wenn die Verzauberung entfernt wird."
-                    },
-                    "item": {
-                        "label": "Zusätzliche Items",
-                        "hint": "Diese zusätzlichen Items werden der Kreatur hinzugefügt, wenn eines ihrer Items verzaubert wird, und werden entfernt, wenn die Verzauberung jemals entfernt wird."
-                    }
-                }
-            }
+    "DND5E.ABILITY": "{'Configure': {'Title': '{ability} bearbeiten'}, 'SECTIONS': {'Bonuses': {'Label': '{ability} Boni', 'Hint': 'Diese Boni gelten für Attributs- und Rettungswürfe, die sich auf {ability} beziehen.'}, 'Global': {'Label': 'Globale Boni', 'Hint': 'Diese Boni gelten für Attributs- und Rettungswürfe, die sich auf beliebige Attribute beziehen.'}, 'Score': '{ability}wert'}}",
+    "DND5E.AC": "RK",
+    "DND5E.ACTIVATION": {
+        "Category": {
+            "Monster": "Monster",
+            "Standard": "Standard",
+            "Time": "Zeit",
+            "Vehicle": "Fahrzeug"
         },
-        "enchant": {
-            "label": "Verzauberung Konfiguration",
-            "identifier": {
-                "label": "Klassen-ID",
-                "hint": "ID, die verwendet wird, um zu bestimmen, ob die Charakterstufe oder eine bestimmte Klassenstufe für die Begrenzung der Verzauberungsstufe verwendet werden soll."
-            }
-        },
-        "restrictions": {
-            "label": "Einschränkung",
-            "hint": "Einschränkungen hinsichtlich der Art des Items, auf das diese Verzauberung angewendet werden kann.",
-            "allowMagical": {
-                "label": "Erlaube Magisches",
-                "hint": "Erlaube, dass Items, die bereits magisch sind, verzaubert werden können."
-            },
-            "categories": {
-                "label": "Gültige Kategorien",
-                "hint": "Spezifische Item-Kategorien, auf die diese Verzauberung angewendet werden kann."
-            },
-            "properties": {
-                "label": "Gültige Eigenschaften",
-                "hint": "Bestimmte Eigenschaften des Items, die vorhanden sein müssen, damit diese Verzauberung angewendet werden kann."
-            },
-            "type": {
-                "label": "Item-Typ",
-                "hint": "Typ des Items, auf das diese Verzauberung angewendet werden kann.",
-                "Any": "Jeder verzauberbare Typ"
-            }
-        }
-    },
-    "SECTIONS": {
-        "Enchanting": "Verzauberung",
-        "Enchantments": "Verzauberungen",
-        "Restrictions": "Einschränkungen"
-    },
-    "DropArea": "Platziere das Item hier, um es zu verzaubern...",
-    "Enchanted": "{current} &sol; {max} Verzaubert",
-    "Enchantment": {
-        "Action": {
-            "Create": "Erstelle Verzauberung",
-            "Delete": "Entferne Verzauberung"
-        },
-        "Empty": "Keine zugehörigen Verzauberungen. Verwende die Schaltfläche <i class=\"fas fa-plus\"></i> oben, um eine zu erstellen, oder wähle eine vorhandene Verzauberung aus dem Dropdown-Menü aus."
-    },
-    "Warning": {
-        "ConcentrationEnded": "Diese Verzauberung kann nicht angewendet werden, da die Konzentration beendet ist.",
-        "MissingProperty": "Item muss eine dieser Eigenschaften haben, um verzaubert zu werden: {validProperties}.",
-        "NoMagicalItems": "Items, die bereits magisch sind, können nicht verzaubert werden.",
-        "NoSubtype": "Nur {allowedType}-Items können mit dieser Verzauberung verzaubert werden, aber dieses Item hat keinen Subtyp.",
-        "WrongType": "{incorrectType} Items können nicht mit dieser Verzauberung verzaubert werden, nur {allowedType} Items sind erlaubt."
-    }
-},
-"DND5E.ENCHANTMENT": {
-    "Action": {
-        "Apply": "Verzauberung anwenden",
-        "Disable": "Verzauberung deaktivieren",
-        "Edit": "Verzauberung bearbeiten",
-        "Enable": "Verzauberung aktivieren",
-        "Remove": "Verzauberung entfernen"
-    },
-    "Category": {
-        "Active": "Aktive Verzauberungen",
-        "General": "Verzauberungen",
-        "Inactive": "Inaktive Verzauberungen"
-    },
-    "FIELDS": {
-        "enchantment": {
-            "label": "Verzauberung Konfiguration",
-            "items": {
-                "max": {
-                    "label": "Item Grenze",
-                    "hint": "Formel für die maximale Anzahl von Verzauberungen dieser Art, die gleichzeitig aktiv sein können."
+        "FIELDS": {
+            "activation": {
+                "condition": {
+                    "hint": "Bedingung, die erfüllt sein muss, um diese Aktivität zu aktivieren.",
+                    "label": "Aktivierungsbedingung"
                 },
-                "period": {
-                    "label": "Ersatz Periode",
-                    "hint": "Wie oft können Verzauberungen dieser Art auf verschiedene Items übertragen werden?"
-                }
-            }
-        }
-    },
-    "Items": {
-        "Entry": "{item} auf <em>{actor}</em>"
-    },
-    "Label": "Verzauberung",
-    "Warning": {
-        "NotOnActor": "Verzauberungen können nur Items hinzugefügt werden, nicht direkt Akteuren.",
-        "Override": "Dieser Wert wird durch eine Verzauberung verändert und kann nicht bearbeitet werden. Deaktiviere die Verzauberung im Reiter Effekte, um sie zu bearbeiten."
-    }
-},
-   "DND5E.Encumbrance": "Belastung",
-   "DND5E.Environment": "Umgebung",
-   "DND5E.EquipmentBonus": "Magischer Bonus",
-   "DND5E.EquipmentClothing": "Kleidung",
-   "DND5E.EquipmentHeavy": "Schwere Rüstung",
-   "DND5E.EquipmentLight": "Leichte Rüstung",
-   "DND5E.EquipmentMedium": "Mittelschwere Rüstung",
-   "DND5E.EquipmentNatural": "Natürliche Rüstung",
-   "DND5E.EquipmentShield": "Schild",
-   "DND5E.EquipmentShieldProficiency": "Schilde",
-   "DND5E.EquipmentTrinket": "Schmuckstück",
-   "DND5E.EquipmentVehicle": "Fahrzeugausstattung",
-   "DND5E.Equipped": "Angelegt",
-   "DND5E.Exhaustion": "Erschöpfung",
-   "DND5E.ExhaustionLevel": "Erschöpfung Stufe {n}",
-   "DND5E.ExperiencePoints": "Erfahrungspunkte",
-   "DND5E.ExperiencePointsAbbr": "EP",
-   "DND5E.ExperiencePointsBoons": {
-    "one": "{number} Gabe",
-    "other": "{number} Gaben"
-},
-   "DND5E.ExperiencePointsCurrent": "Aktuelle EP",
-   "DND5E.ExperiencePointsFormat": "{value} EP",
-   "DND5E.ExperiencePointsLabel": "Fortschritt zur nächsten Stufe",
-   "DND5E.ExperiencePointsMax": "EP für Nächste Stufe",
-   "DND5E.ExperiencePointsMin": "Minimale EP für Diese Stufe",
-   "DND5E.ExperiencePointsValue": "EP-Wert",
-   "DND5E.Expertise": "Expertise",
-   "DND5E.Eyes": "Augen",
-   "DND5E.Faith": "Glaube",
-   "DND5E.Favorite": "Favorit",
-   "DND5E.FavoriteDrop": "Favorit hinzufügen",
-   "DND5E.FavoriteRemove": "Favorit entfernen",
-   "DND5E.Favorites": "Favoriten",
-   "DND5E.Feature": {
-       "Background": "Hintergrundmerkmal",
-       "Class": {
-           "Label": "Klassenmerkmal",
-           "ArcaneShot": "Arkaner Schuss",
-           "ArtificerInfusion": "Artifizienten-Durchdringung",
-           "ChannelDivinity": "Göttliche Macht fokussieren",
-           "DefensiveTactic": "Defensive Taktik",
-           "EldritchInvocation": "Schauerliche Anrufung",
-           "ElementalDiscipline": "Elementare Disziplin",
-           "FightingStyle": "Kampfstil",
-           "HuntersPrey": "Des Jägers Beute",
-           "Ki": "Ki Fähigkeit",
-           "Maneuver": "Manöver",
-           "Metamagic": "Metamagie Option",
-           "Multiattack": "Mehrfachangriff",
-           "PactBoon": "Segen des Paktes",
-           "PsionicPower": "Psionische Kraft",
-           "Rune": "Rune",
-           "SuperiorHuntersDefense": "Ausserordentliche Verteidigung des Jägers"
-       },
-  "Feat": {
-    "Label": "Talent",
-    "EpicBoon": "Epische Gabe Talent",
-    "FightingStyle": "Kampfstil Talent",
-    "General": "Allgemeines Talent",
-    "Origin": "Ursprung Talent"
-  },
-  "Monster": "Monstermerkmal",
-  "Species": "Speziesmerkmal",
-  "SupernaturalGift": {
-    "Label": "Übernatürliches Geschenk",
-    "Blessing": "Segen",
-    "Charm": "Bezauberung",
-    "EpicBoon": "Epische Gabe"
-  }
-},
-   "DND5E.Focus": {
-       "Label": "Zauberfokus",
-       "Arcane": "Arkaner Fokus",
-       "Druidic": "Druidischer Fokus",
-       "Holy": "Heiliges Symbol"
-   },
-   "DND5E.FeatureActionRecharge": "Aktion Nachladen",
-   "DND5E.FeatureActive": "Aktive Fähigkeiten",
-   "DND5E.FeatureAdd": "Erschaffe Merkmal",
-   "DND5E.FeatureAttack": "Merkmalsangriff",
-   "DND5E.FeaturePassive": "Passives Merkmal ",
-   "DND5E.FeatureRechargeOn": "Wiederaufladen aktiv",
-   "DND5E.FeatureRechargeResult": "1W6 Ergebnis",
-   "DND5E.FeatureSearch": "Merkmale durchsuchen",
-   "DND5E.FeatureUsage": "Merkmalsverwendung",
-   "DND5E.Features": "Merkmale",
-   "DND5E.FeaturesBackground": "Hintergrundmerkmale",
-   "DND5E.FeaturesClass": "{class} Merkmale",
-   "DND5E.FeaturesOther": "Sonstige Merkmale",
-   "DND5E.Feats": "Merkmale",
-   "DND5E.FeetAbbr": "ft.",
-   "DND5E.Filter": "Filter",
-   "DND5E.FilterClear": "Filter löschen",
-   "DND5E.FilterGroupCategory": "Gruppieren nach Kategorien",
-   "DND5E.FilterGroupOrigin": "Gruppieren nach Herkunft",
-   "DND5E.FilterGroupAction": "Gruppieren nach Aktion",
-   "DND5E.FilterNoSpells": "Mit diesem Filter wurden keine Zauber gefunden.",
-   "DND5E.FlagsAlert": "Wachsam",
-   "DND5E.FlagsAlertHint": "Verleiht +5 auf Ini.",
-   "DND5E.FlagsDiamondSoul": "Diamantseele",
-   "DND5E.FlagsDiamondSoulHint": "Erhalte Übung in allen Rettungswürfen.",
-   "DND5E.FlagsElvenAccuracy": "Elfengenauigkeit",
-   "DND5E.FlagsElvenAccuracyHint": "Wenn du bei Würfen für GE, INT, CHA o. WEI im Vorteil bist, darfst du einen Würfel erneut würfeln.",
-   "DND5E.FlagsHalflingLucky": "Halblingsglück",
-   "DND5E.FlagsHalflingLuckyHint": "Bei Proben darfst du deinen Wurf bei einer 1 EINMAL wiederholen.",
-   "DND5E.FlagsInitiativeAdv": "Vorteil bei Initiative",
-   "DND5E.FlagsInitiativeAdvHint": "Durch Merkmale oder magische Gegenstände zur Verfügung gestellt.",
-   "DND5E.FlagsInstructions": "Bearbeite Charaktermerkmale und Talente, die das Verhalten des D&D5e-Systems ändern.",
-   "DND5E.FlagsJOAT": "Alleskönner",
-   "DND5E.FlagsJOATHint": "Halber Übungsbonus auf alle nicht erlernten Fertigkeiten.",
-   "DND5E.FlagsMeleeCriticalDice": "Nahkampf Kritische Schadenswürfel",
-   "DND5E.FlagsMeleeCriticalDiceHint": "Anzahl zusätzlicher Schadenswürfel für kritische Treffer bei Nahkampf-Waffenangriffen.",
-   "DND5E.FlagsObservant": "Aufmerksam",
-   "DND5E.FlagsObservantHint": "Verleiht +5 auf passive Wahrnehmung und Nachforschungen.",
-   "DND5E.FlagsPowerfulBuild": "Mächtiger Körperbau",
-   "DND5E.FlagsPowerfulBuildHint": "Bietet erhöhte Tragfähigkeit.",
-   "DND5E.FlagsReliableTalent": "Verlässliches Talent",
-   "DND5E.FlagsReliableTalentHint": "Schurkenmerkmal Verlässliches Talent.",
-   "DND5E.FlagsRemarkableAthlete": "Bemerkenswerter Athlet.",
-   "DND5E.FlagsRemarkableAthleteHint": "Halber Übungsbonus (aufgerundet) auf körperliche Fertigkeitswürfe und Initiative.",
-   "DND5E.FlagsSave": "Besondere Merkmale aktualisieren",
-   "DND5E.FlagsSpellCritThreshold": "Kritischer Treffer Schwellwert (Zauber)",
-   "DND5E.FlagsSpellCritThresholdHint": "Erweiterter Schwellwert für kritische Treffer bei Angriffen mit Zaubern.",
-   "DND5E.FlagsTavernBrawler": "Kneipenschläger-Talent",
-   "DND5E.FlagsTavernBrawlerHint": "Übung mit improvisierten Waffen.",
-   "DND5E.FlagsTitle": "Besondere Merkmale bearbeiten",
-   "DND5E.FlagsWeaponCritThreshold": "Kritischer Treffer Schwellwert (Waffen)",
-   "DND5E.FlagsWeaponCritThresholdHint": "Erweiterter Schwellwert für kritische Treffer bei Angriffen mit Waffen.",
-   "DND5E.Flat": "Flat",
-   "DND5E.Flaws": "Makel",
-   "DND5E.Formula": "Formel",
-   "DND5E.FormulaCannotContainDiceError": "Formel {name} kann keine Würfelausdrücke enthalten.",
-   "DND5E.FormulaMalformedError": "Problem preparing the {property} formula within {name}.",
-   "DND5E.FormulaMissingReferenceWarn": "The {property} formula within {name} has references to missing data: {references}",
-   "DND5E.Gender": "Geschlecht",
-   "DND5E.GrantedAbilities": "gewährte Fähigkeit",
-   "DND5E.Group": {
-       "Challenge": "Herausforderung",
-       "Member": {
-           "one": "Mitglied",
-           "other": "Mitglieder"
-       },
-       "PlaceMembers": "Platziere Mitglieder",
-       "Primary": {
-           "Remove": "Als primäre Gruppe entfernen",
-           "Set": "Als primäre Gruppe festlegen"
-       },
-       "Type": "Gruppenart",
-       "TypeEncounter": "Begegnung",
-       "TypeGeneric": "Gruppe",
-       "TypeParty": "Gemeinschaft",
-       "Vehicle": {
-           "one": "Fahrzeug",
-           "other": "Fahrzeuge"
-       }
-   },
-   "DND5E.GroupControls": "Steuerung",
-   "DND5E.GroupHP": "Gesamte Trefferpunkte",
-   "DND5E.GroupInventory": "Inventar",
-   "DND5E.GroupSummary": "Eine Gruppe von {members}n",
-   "DND5E.GroupSummaryEmpty": "Leere Gruppe",
-   "DND5E.HP": "TP",
-   "DND5E.HPFormula": "Trefferpunkteformel",
-   "DND5E.HPFormulaError": "Die Trefferpunkte-Formel ist ungültig.",
-   "DND5E.HPFormulaRollMessage": "Wurf mit Trefferpunkteformel",
-   "DND5E.Hair": "Haar",
-   "DND5E.HalfProficient": "Halber Übungsbonus",
-   "DND5E.HEAL": {
-    "Title": "Heilen",
-    "FIELDS": {
-        "healing": {
-            "label": "Heilung",
-            "bonus": {
-                "label": "Heilungsbonus",
-                "hint": "Bonus zum Heilungswurf hinzufügen."
-            },
-            "custom": {
-                "label": "Eigene Heilungsformel",
-                "enabled": {
-                    "label": "Aktiviere Eigene Formel",
-                    "hint": "Sollte die eigene Formel anstelle der Standardwürfel verwendet werden."
-                },
-                "formula": {
-                    "label": "Heilungsformel",
-                    "hint": "Eigene Heilungsformel"
-                }
-            },
-            "denomination": {
-                "label": "Würfel Nennwert",
-                "hint": "Nennwert des zu werfenden Würfels."
-            },
-            "number": {
-                "label": "Würfel Zahl",
-                "hint": "Zahl des zu werfenden Würfels"
-            },
-            "scaling": {
-                "label": "Heilungsskalierung",
-                "mode": {
-                    "label": "Skalierungsmodus",
-                    "hint": "Methode, mit der die Skalierungszunahme berechnet wird."
-                },
-                "number": {
-                    "label": "Würfelskalierung",
-                    "hint": "Anzahl der Würfel, die für jede Skalierungsstufe erhöht werden. Wird auf den ersten Würfel angewendet, der in der Schadensformel gefunden wird, wenn mehr als einer vorhanden ist."
-                },
-                "formula": {
-                    "label": "Skalierungsformel",
-                    "hint": "Beliebige Skalierungsformel, die für jeden Skalierungsschritt multipliziert"
-                }
-            },
-            "types": {
-                "label": "Heilungstyp",
-                "hint": "Art der zugefügten Heilung oder mehrere zur Auswahl für den Nutzer."
-            }
-        }
-    }
-},
-   "DND5E.Healing": "Heilung",
-   "DND5E.HealingRoll": "Heilungswurf",
-   "DND5E.HealingTemp": "Heilung (Temporär)",
-   "DND5E.HealthConditions": "Zustandskonditionen",
-   "DND5E.Height": "Größe",
-   "DND5E.HitDice": "Trefferwürfel",
-   "DND5E.HitDiceAutoSpend": {
-       "Label": "Automatische  Trefferwürfel verwenden",
-       "Hint": "Automatisch Trefferwürfel ausgeben, bis sie aufgebraucht sind oder die Lebenspunkte voll sind."
-   },
-   "DND5E.HitDiceConfig": "Trefferwürfel anpassen",
-   "DND5E.HitDiceConfigHint": "Passt die verbleibenden Tefferwürfelstufen für jede Klasse an.",
-   "DND5E.HitDiceMax": "Maximale Trefferwürfel",
-   "DND5E.HitDiceRemaining": "Verbleibende Trefferwürfel",
-   "DND5E.HitDiceRoll": "Wirf TW",
-   "DND5E.HitDiceWarn": "{name} hat keine {formula} Trefferwürfel übrig!",
-   "DND5E.HitDiceNPCWarn": "{name} hat keine Trefferwürfel übrig!",
-   "DND5E.HitDie": "Trefferwürfel",
-   "DND5E.HitPoints": "Trefferpunkte",
-   "DND5E.HitPointsBonusLevel": "Bonus pro Stufe",
-   "DND5E.HitPointsBonusOverall": "Bonus fest",
-   "DND5E.HitPointsConfig": "Trefferpunkte bearbeiten",
-   "DND5E.HitPointsCurrent": "Aktuelle Trefferpunkte",
-   "DND5E.HitPointsMax": "Maximale Trefferpunkte",
-   "DND5E.HitPointsMin": "Minimale Trefferpunkte",
-   "DND5E.HitPointsOverride": "Maximale Trefferpunkte fest setzen",
-   "DND5E.HitPointsTemp": "Temporäre Trefferpunkte",
-   "DND5E.HitPointsTempShort": "Temporäre TP",
-   "DND5E.HitPointsTempMax": "Temporary Maximum Hit Points",
-   "DND5E.HitPointsTempMaxShort": "Temp Max TP",
-   "DND5E.Ideals": "Ideale",
-   "DND5E.Identified": "Identifiziert",
-   "DND5E.Identifier": "ID",
-   "DND5E.IdentifierError": "ID darf nur Buchstaben (a-z), Zahlen (0-9), Bindestriche (-) und Unterstriche (_) enthalten.",
-   "DND5E.Identify": "Identifizieren",
-   "DND5E.Immunities": "Immunitäten",
-   "DND5E.Initiative": "Initiative",
-   "DND5E.InitiativeAbbr": "Init",
-   "DND5E.InitiativeBonus": "Initiativebonus",
-   "DND5E.InitiativeConfig": "Initiative bearbeiten",
-   "DND5E.InitiativeConfigHint": "Initiativmodifikator und Boni für diesen Akteur festlegen.",
-   "DND5E.InitiativeRoll": "Initiativewurf",
-   "DND5E.Inspiration": "Inspiration",
-   "DND5E.Inventory": "Inventar",
-   "DND5E.InventorySearch": "Inventar durchsuchen",
-   "DND5E.Issues": "Issues",
-   "DND5E.Item": {
-       "Category": {
-           "Label": "Ketegorie",
-           "Physical": "Physisch"
-       },
-       "Property": {
-           "Adamantine": "Adamant",
-           "Ammunition": "Geschosse",
-           "Concentration": "Konzentration",
-           "Finesse": "Finesse",
-           "Firearm": "Feuerwaffe",
-           "Focus": "Fokus",
-           "Heavy": "Schwer",
-           "Light": "Leicht",
-           "Loading": "Laden",
-           "Magical": "Magisch",
-           "Material": "Material",
-           "Reach": "Reichweite",
-           "Reload": "Nachladen",
-           "Returning": "Rückkehrend",
-           "Ritual": "Ritual",
-           "Silvered": "Versilbert",
-           "Somatic": "Gestik",
-           "Special": "Spezial",
-           "StealthDisadvantage": "Heimlichkeit Nachteil",
-           "Thrown": "Wurfwaffe",
-           "TwoHanded": "Zweihändig",
-           "Verbal": "Verbal",
-           "Versatile": "Vielseitig",
-           "WeightlessContents": "Gewichtsloser Inhalt"
-       }
-   },
-   "DND5E.ItemActionType": "Aktionstyp",
-   "DND5E.ItemActivation": "Aktivierung",
-   "DND5E.ItemActivationCondition": "Aktivierungsbedingung",
-   "DND5E.ItemActivationCost": "Aktivierungskosten",
-   "DND5E.ItemActivationType": "Aktivierungsart",
-   "DND5E.ItemAmmoProperties": "Munitionseigenschaften",
-   "DND5E.ItemAttackBonus": "Bonus für Angriffwurf",
-   "DND5E.ItemAttackFlat": "Pauschaler Bonus",
-   "DND5E.ItemAttackFlatHint": "Wenn diese Option angekreuzt ist, darfst du dem Angriffswurf keine weiteren Boni hinzufügen, außer denen, die hier angegeben sind.",
-   "DND5E.ItemBackgroundDetails": "Hintergrund-Details",
-   "DND5E.ItemClassDetails": "Klassen-Details",
-   "DND5E.ItemConsumableActivation": "Verbrauchsgut-Aktivierung",
-   "DND5E.ItemConsumableDetails": "Verbrauchsgut-Details",
-   "DND5E.ItemConsumableProperties": "Verbrauchsgut-Eigenschaften",
-   "DND5E.ItemConsumableStatus": "Verbrauchsgut-Status",
-   "DND5E.ItemConsumableSubtype": "{category}-Typ",
-   "DND5E.ItemConsumableType": "Verbrauchsgut-Typ",
-   "DND5E.ItemConsumableUsage": "Verbrauchsgut-Nutzung",
-   "DND5E.ItemContainerCapacity": "Kapazität",
-   "DND5E.ItemContainerCapacityItems": "Gegenstand",
-   "DND5E.ItemContainerCapacityMax": "Max. Kapazität",
-   "DND5E.ItemContainerCapacityType": "Kapazitätstyp",
-   "DND5E.ItemContainerCapacityWeight": "Gewicht",
-   "DND5E.ItemContainerDetails": "Behälter-Details",
-   "DND5E.ItemContainerProperties": "Behälter-Eigenschaften",
-   "DND5E.ItemContainerStatus": "Behälterstatus",
-   "DND5E.ItemCreate": "Gegenstand erstellen",
-   "DND5E.ItemCritExtraDamage": "Zusätz. kritischer Schaden",
-   "DND5E.ItemCritThreshold": "Grenzwert kritischer Treffer",
-   "DND5E.ItemDelete": "Gegenstand löschen",
-   "DND5E.ItemEdit": "Gegenstand bearbeiten",
-   "DND5E.ItemEquipmentAction": "Ausrüstungaktion",
-   "DND5E.ItemEquipmentBase": "Basisausrüstung",
-   "DND5E.ItemEquipmentDetails": "Ausrüstungs-Details",
-   "DND5E.ItemEquipmentDexMod": "Max. Geschicklichkeitsmodifikator",
-   "DND5E.ItemEquipmentDexModAbbr": "Max. Ges",
-   "DND5E.ItemEquipmentProperties": "Ausstattungseigenschaften",
-   "DND5E.ItemEquipmentStatus": "Ausrüstungsstatus",
-   "DND5E.ItemEquipmentStealthDisav": "Erzwingt Heimlichkeitsnachteil",
-   "DND5E.ItemEquipmentType": "Ausrüstungstyp",
-   "DND5E.ItemEquipmentUsage": "Ausrüstungsnutzung",
-   "DND5E.ItemFeatureDetails": "Merkmal-Details",
-   "DND5E.ItemFeatureProperties": "Merkmal Eigenschaften",
-   "DND5E.ItemFeatureSubtype": "{category}-Typ",
-   "DND5E.ItemFeatureType": "Merkmal-Typ",
-   "DND5E.ItemLootDetails": "Beute-Details",
-   "DND5E.ItemLootProperties": "Beuteeigenschaften",
-   "DND5E.ItemLootSubtype": "{category} Typ",
-   "DND5E.ItemLootType": "Beute-Typ",
-   "DND5E.ItemLossRoll": "{name} verliert {count} Aufladungen",
-   "DND5E.ItemName": "Gegenstandsname",
-   "DND5E.ItemNew": "Neu: {type}",
-   "DND5E.ItemRarityArtifact": "artefakt",
-   "DND5E.ItemRarityCommon": "gewöhnlich",
-   "DND5E.ItemRarityMundane": "alltäglich",
-   "DND5E.ItemRarityLegendary": "legendär",
-   "DND5E.ItemRarityRare": "selten",
-   "DND5E.ItemRarityUncommon": "ungewöhnlich",
-   "DND5E.ItemRarityVeryRare": "sehr selten",
-   "DND5E.ItemRechargeCheck": "{name} Aufladeprüfung",
-   "DND5E.ItemRechargeFailure": "Fehlschlag!",
-   "DND5E.ItemRechargeSuccess": "Erfolgreich!",
-   "DND5E.ItemRecoveryFormulaWarning": "{name} kann keine Aufladungen zurückerhalten. Ungültige Formel: '{formula}'.",
-   "DND5E.ItemRecoveryRoll": "{name} erhält {count} Aufladungen zurück",
-   "DND5E.ItemRecoveryRollMax": "{name} erhält alle Aufladungen zurück",
-   "DND5E.ItemRequiredStr": "Benötigte Stärke",
-   "DND5E.ItemSiegeProperties": "Belagerungs-Eigenschaften",
-   "DND5E.ItemSpeciesDetails": "Spezies-Details",
-   "DND5E.ItemSubclassDetails": "Unterklassen-Details",
-   "DND5E.ItemToolBase": "Basiswerkzeug",
-   "DND5E.ItemToolBonus": "Werkzeugbonus",
-   "DND5E.ItemToolDetails": "Werkzeugdetails",
-   "DND5E.ItemToolProficiency": "Handwerkliches Geschick",
-   "DND5E.ItemToolProperties": "Werkzeug Eigenschaften",
-   "DND5E.ItemToolStatus": "Werkzeugstatus",
-   "DND5E.ItemToolType": "Werkzeugtyp",
-   "DND5E.ItemToolUsage": "Werkzeug Nutzung",
-   "DND5E.ItemVehicleProperties": "Fahrzeuge Details",
-   "DND5E.ItemView": "Item anzeigen",
-   "DND5E.ItemWeaponAttack": "Waffenangriff",
-   "DND5E.ItemWeaponBase": "Basiswaffe",
-   "DND5E.ItemWeaponDetails": "Waffendetails",
-   "DND5E.ItemWeaponProperties": "Waffeneigenschaften",
-   "DND5E.ItemWeaponStatus": "Waffenstatus",
-   "DND5E.ItemWeaponType": "Waffentyp",
-   "DND5E.ItemWeaponUsage": "Waffennutzung",
-   "DND5E.JackOfAllTrades": "Alleskönner",
-   "DND5E.LairAct": "Nutzungen Hortaktionen",
-   "DND5E.LairActionInitiative": "Hortaktion Initiativwert",
-   "DND5E.LairActionLabel": "Hort-Aktion",
-   "DND5E.Languages": "Sprachen",
-   "DND5E.LanguagesAarakocra": "Aarakocra",
-   "DND5E.LanguagesAbyssal": "Abyssisch",
-   "DND5E.LanguagesAquan": "Aqual",
-   "DND5E.LanguagesAuran": "Auran",
-   "DND5E.LanguagesCelestial": "Celestisch",
-   "DND5E.LanguagesCommon": "Gemeinsprache",
-   "DND5E.LanguagesDeepSpeech": "Tiefensprache",
-   "DND5E.LanguagesDraconic": "Drakonisch",
-   "DND5E.LanguagesDruidic": "Druidisch",
-   "DND5E.LanguagesDwarvish": "Zwergisch",
-   "DND5E.LanguagesElvish": "Elfisch",
-   "DND5E.LanguagesExotic": "Exotische Sprachen",
-   "DND5E.LanguagesExoticLegacy": "Exotische Sprachen",
-   "DND5E.LanguagesGiant": "Riesisch",
-   "DND5E.LanguagesGith": "Gith",
-   "DND5E.LanguagesGnoll": "Gnollisch",
-   "DND5E.LanguagesGnomish": "Gnomisch",
-   "DND5E.LanguagesGoblin": "Goblinisch",
-   "DND5E.LanguagesHalfling": "Halbingisch",
-   "DND5E.LanguagesIgnan": "Ignal",
-   "DND5E.LanguagesInfernal": "Infernalisch",
-   "DND5E.LanguagesOrc": "Orkisch",
-   "DND5E.LanguagesPrimordial": "Urtümlich",
-   "DND5E.LanguagesStandard": "Standard Sprachen",
-   "DND5E.LanguagesSylvan": "Sylvanisch",
-   "DND5E.LanguagesTerran": "Terral",
-   "DND5E.LanguagesThievesCant": "Diebessprache",
-   "DND5E.LanguagesUndercommon": "Gemeinsprache der Unterreiche",
-   "DND5E.LegAct": "Legendäre Aktionen",
-   "DND5E.LegActN.one": "1. Legendäre Aktion",
-   "DND5E.LegActN.two": "2. Legendäre Aktion",
-   "DND5E.LegActN.few": "3. Legendäre Aktion",
-   "DND5E.LegActN.other": "{n}. Legendäre Aktion",
-   "DND5E.LegActMax": "Maximale Legendäre Aktionen",
-   "DND5E.LegActRemaining": "Verbleibende Legendäre Aktionen",
-   "DND5E.LegRes": "Legendäre Resistenzen",
-   "DND5E.LegResN.one": "1. Legendäre Resistenz",
-   "DND5E.LegResN.two": "2. Legendäre Resistenz",
-   "DND5E.LegResN.few": "3. Legendäre Resistenz",
-   "DND5E.LegResN.other": "{n}. Legendäre Resistenz",
-   "DND5E.LegResMax": "Maximale Legendäre Resistenzen",
-   "DND5E.LegResRemaining": "Verbleibende Legendäre Resistenzen",
-   "DND5E.LegendaryActionLabel": "Legendäre Aktion",
-   "DND5E.Level": "Stufe",
-   "DND5E.LevelActionDecrease": "Stufenaufstieg",
-   "DND5E.LevelActionIncrease": "Stufenabstieg",
-   "DND5E.LevelCount": "{ordinal} Stufe",
-   "DND5E.LevelLimit": {
-       "Label": "Stufen Grenze",
-       "Max": "Maximale Stufe",
-       "Min": "Minimale Stufe"
-   },
-   "DND5E.LevelNumber": "Stufe {level}",
-   "DND5E.LevelPl": "Stufen",
-   "DND5E.LevelScaling": "Stufenanpassung",
-   "DND5E.LimitedUses": "Limitierte Nutzungen",
-   "DND5E.LimitedUsesAvailable": "Verbleibende Nutzungen",
-   "DND5E.LimitedUsesMax": "Maximale Nutzungen",
-   "DND5E.LimitedUsesPer": "Rückerlangung",
-   "DND5E.LimitedUsesPrompt": "Abfrage benutzen",
-   "DND5E.LimitedUsesPromptTooltip": "Wenn nicht aktiviert, wird die Abfrage beim verbrauchen von Nutzungen unterdrückt.",
-   "DND5E.Long": "Weit",
-   "DND5E.LongRest": "Lange Rast",
-   "DND5E.LongRestEpic": "Lange Rast (1 Stunde)",
-   "DND5E.LongRestGritty": "Lange Rast (7 Tage)",
-   "DND5E.LongRestHint": "Eine lange Rast nehmen? Hierbei erhältst du Trefferpunkte, die Hälfte deiner maximalen Trefferwürfel, Klassenressourcen, Gegenstandsladungen und Zauberplätze zurück.",
-   "DND5E.LongRestHintGroup": "Lange Rast nehmen? Bei einer langen Rast erhalten Gruppenmitglieder Trefferpunkte, anteilig Trefferwürfel, Klassenressourcen, Zauberplätze und manche Gegenstandsnutzungen zurück.",
-   "DND5E.LongRestNormal": "Lange Rast (8 Std.)",
-   "DND5E.LongRestOvernight": "Lange Rast (Neuer Tag)",
-   "DND5E.LongRestRecovery": "Rückerlangen nach Langer Rast",
-   "DND5E.LongRestResult": "{name} macht eine Lange Rast und erhält {health} TP und {dice} TW.",
-   "DND5E.LongRestResultHitDice": "{name} nimmt eine lange Rast und erlangt {dice} Trefferwürfel zurück.",
-   "DND5E.LongRestResultHitPoints": "{name} nimmt eine lange Rast und erlangt {health} Trefferpunkte zurück.",
-   "DND5E.LongRestResultShort": "{name} nimmt eine lange Rast.",
-   "DND5E.Loot.Art": "Kunstgegenstand",
-   "DND5E.Loot.Gear": "Abenteuerausrüstung",
-   "DND5E.Loot.Gem": "Edelstein",
-   "DND5E.Loot.Junk": "Schrott",
-   "DND5E.Loot.Material": "Material",
-   "DND5E.Loot.Resource": "Ressource",
-   "DND5E.Loot.Treasure": "Schatz",
-   "DND5E.MagicalBonus": "Magischer Bonus",
-   "DND5E.Materials": "Material",
-   "DND5E.Max": "Max",
-   "DND5E.MaxCharacterLevelExceededWarn": "Charakter kann nicht über Stufe {max} hinaus aufsteigen.",
-   "DND5E.MaxClassLevelExceededWarn": "Klasse kann nicht über Stufe {max} hinaus aufsteigen.",
-   "DND5E.MaxClassLevelMinimumWarn": "Klasse muss mindestens eine Stufe haben.",
-   "DND5E.Maximum": "Maximum",
-   "DND5E.Minimum": "Minimum",
-   "DND5E.Modifier": "Modifikator",
-   "DND5E.ModuleArtConfigH": "Legt Module für Medien (z.B. für Illustrationen von Akteurporträts und Spielfiguren) fest.",
-   "DND5E.ModuleArtConfigL": "Medien bearbeiten",
-   "DND5E.ModuleArtConfigN": "Medien aus Modulen",
-   "DND5E.ModuleArtConfigPortraits": "Porträts",
-   "DND5E.ModuleArtConfigTokens": "Spielfiguren",
-   "DND5E.ModuleArtPriorityDecrease": "Priorität senken",
-   "DND5E.ModuleArtPriorityHint": "Mit den Pfeilen kann die Priorisierung der Art-Quellen angepasst werden. Wenn für einen Akteur Medien aus mehreren Quellen vorliegen, werden die mit der höchsten Priorität genutzt.",
-   "DND5E.ModuleArtPriorityIncrease": "Priorität erhöhen",
-   "DND5E.Multiple": "Mehrfach",
-   "DND5E.Movement": "Bewegung",
-   "DND5E.MovementAir": "Luft",
-   "DND5E.MovementBurrow": "Graben",
-   "DND5E.MovementClimb": "Klettern",
-   "DND5E.MovementConfig": "Bewegung einstellen",
-   "DND5E.MovementConfigHint": "Bearbeite die Bewegungsgeschwindigkeit und spezielle Bewegungsarten dieser Kreatur.",
-   "DND5E.MovementFly": "Fliegen",
-   "DND5E.MovementHover": "Schweben",
-   "DND5E.MovementLand": "Land",
-   "DND5E.MovementSpeeds": "Bewegungsrate",
-   "DND5E.MovementSwim": "Schwimmen",
-   "DND5E.MovementUnits": "Einheiten",
-   "DND5E.MovementWalk": "Laufen",
-   "DND5E.MovementWater": "Wasser",
-   "DND5E.Multiplier": "Multiplikator",
-   "DND5E.MythicActionLabel": "Mythische Aktion",
-   "DND5E.Name": "Charakter Name",
-   "DND5E.NameUnidentified": "Unidentifizierter Name",
-   "DND5E.NewDay": "Neuer Tag?",
-   "DND5E.NewDayHint": "Fähigkeiten mit begrenzten Nutzungen zurückerlangen, die pro Tag wiederaufladen?",
-   "DND5E.SAVE": {
-    "Title": {
-        "one": "Rettungswurf",
-        "other": "Rettungswürfe"
-    },
-    "FIELDS": {
-        "damage": {
-            "label": "Rettungswurf Schaden",
-            "onSave": {
-                "label": "Schaden be iErfolg",
-                "hint": "Wie viel Schaden sollte bei einem Erfolgreichen Rettungswurf zugefügt werden?",
-                "Full": "Vollständiger Schaden",
-                "Half": "Halber Schaden",
-                "None": "Kein Schaden"
-            },
-            "parts": {
-                "label": "Schadensbestandteil",
-                "hint": "Einzelne Schadensbestandteile dem Wurf hinzufügen."
-            }
-        },
-        "effects": {
-            "onSave": {
-                "label": "Immer Anwenden",
-                "hint": "Dieser Effekt wird immer angewendet, auch wenn das Ziel seinen Rettungswurf schafft."
-            }
-        },
-        "save": {
-            "label": "Rettungswurf Details",
-            "ability": {
-                "label": "Herausforderndes Attribut",
-                "hint": "Attribut, das gewürfelt werden muss, um zu versuchen, den Rettungswurf zu bestehen."
-            },
-            "dc": {
-                "label": "Schwierigkeitsgrad",
-                "calculation": {
-                    "label": "SG Berechnung",
-                    "hint": "Methode oder Attribut, das zur Berechnung des Schwierigkeitsgrades verwendet wird."
-                },
-                "formula": {
-                    "label": "SG Formel",
-                    "hint": "Eigene Formel oder fester Wert zur Definition Rettungs-SG."
-                },
-                "CustomFormula": "Eigene Formel",
-                "DefaultFormula": "8 + @mod + @prof"
-            }
-        }
-    },
-    "OnSave": "Bei Erfolg"
-},
-   "DND5E.NoCharges": "Keine Ladungen",
-   "DND5E.NoSpellLevels": "Dieser Charakter hat keine Zaubererstufen, aber du kannst Zauber manuell hinzufügen.",
-   "DND5E.FLAGS": {
-    "EnhancedDualWielding": {
-        "Name": "Verbesserte Beidgändigkeit",
-        "Hint": "Erlaube Bonusaktionen für zusätzliche Angriffe mit jeder Nahkampfwaffe ohne die Zweihändig Eigenschaft."
-    }
-},
-   "DND5E.None": "Nichts",
-   "DND5E.NoneActionLabel": "Keine",
-   "DND5E.Normal": "Normal",
-   "DND5E.NotProficient": "Nicht geübt",
-   "DND5E.Notes": "Notizen",
-   "DND5E.NPC": "NSC",
-   "DND5E.Number": "Anzahl",
-   "DND5E.OtherFormula": "Andere Formel",
-   "DND5E.PactMagic": "Paktmagie",
-   "DND5E.Passive": "Passiv",
-   "DND5E.PassivePerception": "Passive Wahrnehmmung",
-   "DND5E.Period": "Periode",
-   "DND5E.PersonalityTraits": "Persönlichkeitsmerkmale",
-   "DND5E.Polymorph": "Verwandlung",
-   "DND5E.PolymorphAcceptSettings": "Eigene Einstellung",
-   "DND5E.PolymorphAddTemp": "Füge die TP des Ziels als Temporäre TP hinzu",
-   "DND5E.PolymorphCustomTransformation": "Eigene Verwandlung",
-   "DND5E.PolymorphEffectTransformation": "Effekte bei Verwandlung",
-   "DND5E.PolymorphKeepAE": "Behalte alle Effekte (überschreibt andere Effekt-Behalten-Optionen).",
-   "DND5E.PolymorphKeepBackgroundAE": "Behalte Effekte von Hintergründen",
-   "DND5E.PolymorphKeepBio": "Biographie behalten",
-   "DND5E.PolymorphKeepClass": "Behalte Übungsbonus (lässt Klasseneinträge im Bogen)",
-   "DND5E.PolymorphKeepClassAE": "Behalte Effekte von Klassen und Unterklassen",
-   "DND5E.PolymorphKeepEquipmentAE": "Behalte Effekte von Ausrüstung",
-   "DND5E.PolymorphKeepFeats": "Behalte Merkmale",
-   "DND5E.PolymorphKeepFeatureAE": "Behalte Effekte von Merkmalen",
-   "DND5E.PolymorphKeepHP": "Behalte TP & TW",
-   "DND5E.PolymorphKeepItems": "Ausrüstung behalten",
-   "DND5E.PolymorphKeepMental": "Behalte Mentale Attributswerte (Int, Wei, Cha)",
-   "DND5E.PolymorphKeepOriginAE": "Behalte Effekt vom Akteur (d.h. Effekte, die nicht an Zaubern, Merkmalen etc. hängen)",
-   "DND5E.PolymorphKeepOtherOriginAE": "Behalte Effekte die von anderen Akteuren stammen",
-   "DND5E.PolymorphKeepPhysical": "Behalte physikalische Attributswerte (Stä, Ges, Kon)",
-   "DND5E.PolymorphKeepSaves": "Behalte Rettungswürfe",
-   "DND5E.PolymorphKeepSelf": "Alles behalten (ändert nur Bild/Größe, z.B. für Selbstverkleidung)",
-   "DND5E.PolymorphKeepSkills": "Behalte Fertigkeiten",
-   "DND5E.PolymorphKeepSpellAE": "Behalte Effekte, die von eigenen Zaubern stammen",
-   "DND5E.PolymorphKeepSpells": "Behalte Zauber",
-   "DND5E.PolymorphKeepType": "Behalte Kreaturentyp",
-   "DND5E.PolymorphKeepVision": "Behalte Sicht (Charakter und Figuren)",
-   "DND5E.PolymorphMergeSaves": "Rettungswürfe zusammenführen (benutze den Besten)",
-   "DND5E.PolymorphMergeSkills": "Fertigkeiten zusammenführen (benutze den Besten)",
-   "DND5E.PolymorphPromptTitle": "Charakter-Verwandlung",
-   "DND5E.PolymorphRestoreTransformation": "Verwandlung aufheben",
-   "DND5E.PolymorphRevertNoOriginalActorWarn": "Ursprungsakteur mit Referenz '{reference}' nicht gefunden",
-   "DND5E.PolymorphRevertWarn": "Keine Erlaubnis, den verwandelten Zustand dieses Charakters umzukehren.",
-   "DND5E.PolymorphSelf": "Nur Aussehen",
-   "DND5E.PolymorphTmpClass": "Temporäre Klasse",
-   "DND5E.PolymorphTokens": "Alle verknüpften Figuren umwandeln?",
-   "DND5E.PolymorphWarn": "Keine Erlaubnis diesen Charakter zu verwandeln!",
-   "DND5E.PolymorphWildShape": "Tiergestalt",
-   "DND5E.Portrait": "Porträt",
-   "DND5E.PowerfulCritical": "Mächtige kritische Treffer",
-   "DND5E.CRLabel": "HG {cr}",
-   "DND5E.Prepared": "Vorbereitet",
-   "DND5E.Prerequisites": {
-       "Header": "Merkmal Voraussetzungen",
-       "FIELDS": {
-           "prerequisites": {
-               "level": {
-                   "label": "Benötigte Stufe",
-                   "hint": "Charakter- oder Klassenstufe, die für die Auswahl dieses Merkmals beim Stufenaufstieg erforderlich ist."
-               }
-           }
-       }
-   },
-   "DND5E.Price": "Preis",
-   "DND5E.Proficiency": "Übungsbonus",
-   "DND5E.ProficiencyBonus": "Übungsbonus",
-   "DND5E.ProficiencyConfigurationHint": "Übung und Boni bearbeiten.",
-   "DND5E.ProficiencyConfigureTitle": "{label} bearbeiten",
-   "DND5E.ProficiencyLevel": "Übungsstufe",
-   "DND5E.Proficient": "Geübt",
-   "DND5E.Properties": "Eigenschaften",
-   "DND5E.PropertyBase": "Basis",
-   "DND5E.PropertyTotal": "Gesamt",
-   "DND5E.Public": "Öffentlich",
-   "DND5E.Quantity": "Anzahl",
-   "DND5E.QuantityAbbr": "Anz",
-   "DND5E.QuantityFormula": "Anzahl Formel",
-   "DND5E.QuantityRoll": "Anzahl der Würfe",
-   "DND5E.RacialTraits": "Volkseigenschaften",
-   "DND5E.RANGE": {
-    "FIELDS": {
-        "range": {
-            "label": "Reichweite",
-            "long": {
-                "label": "Maximalreichweite",
-                "hint": "Große Angriffsreichweite der Waffe, falls vorhanden."
-            },
-            "override": {
-                "label": "Überschreibe Reichweite",
-                "hint": "Verwende diese Werte für die Reichweite anstelle der Werte für das Item, wenn du diese Aktivität verwendest."
-            },
-            "reach": {
-                "label": "Reichweite"
-            },
-            "special": {
-                "label": "Spezielle Reichweite",
-                "hint": "Beschreibung einer Speziellen Reichweite."
-            },
-            "units": {
-                "label": "Reichweiten Einheit",
-                "hint": "Einheiten zur Messung der Reichweite."
-            },
-            "value": {
-                "label": "Reichweitenwert",
-                "hint": "Wert der Reichweite in den angegebenen einheiten, falls zutreffend."
-            }
-        }
-    }
-},
-   "DND5E.Range": "Reichweite",
-   "DND5E.RangeDistance": "Distanz",
-   "DND5E.RangeLong": "Maximalreichweite",
-   "DND5E.RangeNormal": "Grundreichweite",
-   "DND5E.RangeUnits": "Reichweitentyp oder Einheit",
-   "DND5E.Rarity": "Seltenheit",
-   "DND5E.Reaction": "Reaktion",
-   "DND5E.ReactionAbbr": "R",
-   "DND5E.ReactionPl": "Reaktionen",
-   "DND5E.Recharge": "Aufladen",
-   "DND5E.Recovery": "Wiederherst.",
-   "DND5E.RecoveryFormula": "Formel zum Wiederaufladen",
-   "DND5E.RequiredMaterials": "Benötigte Materialien",
-   "DND5E.Requirements": "Voraussetzungen",
-   "DND5E.Resistances": "Resistenz",
-   "DND5E.ResourceLabel": "Name",
-   "DND5E.ResourceMax": "Ressourcenmaximum",
-   "DND5E.ResourcePrimary": "Ressource 1",
-   "DND5E.ResourceSecondary": "Ressource 2",
-   "DND5E.ResourceTertiary": "Ressource 3",
-   "DND5E.ResourceValue": "Ressourcenwert",
-   "DND5E.Resources": "Ressourcen",
-   "DND5E.Rest": "Rast",
-   "DND5E.RestL": "L. Rast",
-   "DND5E.RestS": "K. Rast",
-   "DND5E.Ritual": "Ritual",
-   "DND5E.RitualAbbr": "R",
-   "DND5E.Roll": "Wurf",
-   "DND5E.RollConfiguration": {
-    "Title": "Wurf Konfigurieren",
-    "Configuration": "Konfiguration",
-    "Rolls": "Würfe"
-},
-   "DND5E.RollExample": "z.B. +1W4",
-   "DND5E.RollMode": "Wurf Modus",
-   "DND5E.RollSituationalBonus": "Situativer Bonus?",
-   "DND5E.Rule": {
-       "Tooltip": "Tooltip",
-       "Type": {
-           "Condition": "Zustand",
-           "Label": "Regel-Typ",
-           "Rule": "Regel"
-       }
-   },
-   "DND5E.SaveBonus": "Rettungswurfbonus",
-   "DND5E.SaveDC": "SG {dc} {ability}",
-   "DND5E.SaveGlobalBonusHint": "Dieser Bonus gilt für alle Rettungswürfe dieses Akteurs.",
-   "DND5E.Scroll": {
-       "CreateFrom": "Schriftrolle von {spell} erstellen",
-       "CreateScroll": "Schriftrolle erstellen",
-       "Details": "Schriftrollendetails",
-       "Explanation": {
-           "Label": "Erklärung",
-           "Hint": "Menge der Regeln zur Verwendung von Zauberrollen, die in die erstellte Schriftrolle aufgenommen werden.",
-           "Complete": "Komplett",
-           "Reference": "Referenz"
-       },
-       "RequiresConcentration": "Benötigt Konzentration",
-       "SaveDC": "Zauber SG",
-       "Values": "Zauber Werte"
-   },
-   "DND5E.SavePromptTitle": "{ability} Rettungswurf",
-   "DND5E.SavingThrow": "Rettungswurf",
-   "DND5E.SavingThrowDC": "SG {dc} {ability}-Rettungswurf",
-   "DND5E.SavingThrowRoll": "Werfe {ability}-Rettungswurf",
-   "DND5E.ScalingFormula": "Skalierungsformel",
-   "DND5E.ScalingMode": "Skalierungsmodus",
-   "DND5E.ScalingValue": "Skalierungswert",
-   "DND5E.School": "Schule",
-   "DND5E.SchoolAbj": "Bannmagie",
-   "DND5E.SchoolCon": "Beschwörung",
-   "DND5E.SchoolDiv": "Erkenntnismagie",
-   "DND5E.SchoolEnc": "Verzauberung",
-   "DND5E.SchoolEvo": "Hervorrufung",
-   "DND5E.SchoolIll": "Illusion",
-   "DND5E.SchoolNec": "Nekromantie",
-   "DND5E.SchoolTrs": "Verwandlung",
-   "DND5E.SenseBlindsight": "Blindsicht",
-   "DND5E.SenseDarkvision": "Dunkelsicht",
-   "DND5E.SenseSpecial": "Spezielle Sinne",
-   "DND5E.Shape": "Form",
-   "DND5E.SenseTremorsense": "Erschütterungssinn",
-   "DND5E.SenseTruesight": "Wahrsicht",
-   "DND5E.SenseUnits": "Einheiten",
-   "DND5E.Senses": "Sinne",
-   "DND5E.SensesConfig": "Sinne bearbeiten",
-   "DND5E.SensesConfigHint": "Bearbeite spezielle sensorische Wahrnehmungsfähigkeiten, die dieser Charakter besitzt.",
-   "DND5E.SheetClassCharacter": "Standard 5e Charakterbogen",
-   "DND5E.SheetClassCharacterLegacy": "Legacy 5e Charakterbogen",
-   "DND5E.SheetClassClassSummary": "Standard 5e Klassenübersichtsbogen",
-   "DND5E.SheetClassContainer": "Standard 5e Behälterbogen",
-   "DND5E.SheetClassContainerLegacy": "Legacy 5e Behälterbogen",
-   "DND5E.SheetClassGroup": "Standard 5e Gruppenbogen",
-   "DND5E.SheetClassItem": "Standard 5e Gegenstandsbogen",
-   "DND5E.SheetClassItemLegacy": "Legacy 5e Itembogen",
-   "DND5E.SheetClassJournalEntry": "Standard 5e Notizbogen",
-   "DND5E.SheetClassMapLocation": "Standard 5e Kartenbogen",
-   "DND5E.SheetClassNPC": "Standard 5e NSC-Bogen",
-   "DND5E.SheetClassNPCLegacy": "Legacy 5e NSC-Bogen",
-   "DND5E.SheetClassRule": "Standard 5e Regelbogen",
-   "DND5E.SheetClassSpellList": "Standard 5e Zauberlistenbogen",
-   "DND5E.SheetClassToken": "Standard 5e Figurbogen",
-   "DND5E.SheetClassVehicle": "Standard 5e Fahrzeugbogen",
-   "DND5E.SheetModeEdit": "Bearbeiten",
-   "DND5E.SheetModePlay": "Spielen",
-   "DND5E.ShortRest": "Kurze Rast",
-   "DND5E.ShortRestEpic": "Kurze Rast (5 Min.)",
-   "DND5E.ShortRestGritty": "Kurze Rast (8 Std.)",
-   "DND5E.ShortRestHint": "Kurze Rast einlegen? Bei einer kurzen Rast können verbleibende Trefferwürfel ausgegeben und Ressourcen zurückgewonnen werden.",
-   "DND5E.ShortRestHintGroup": "Kurze Rast nehmen? Bei einer kurzen Rast können Gruppenmitglieder Trefferwürfel nutzen und manche Gegenstandsnutzungen zurückerlangen.",
-   "DND5E.ShortRestNoHD": "Keine Trefferwürfel mehr übrig",
-   "DND5E.ShortRestNormal": "Kurze Rast (1 Std.)",
-   "DND5E.ShortRestOvernight": "Kurze Rast (Neuer Tag)",
-   "DND5E.ShortRestRecovery": "Rückerlangen nach Kurzer Rast",
-   "DND5E.ShortRestResult": "{name} nimmt eine kurze Rast und gibt {dice} TW aus um {health} TP zurückzubekommen.",
-   "DND5E.ShortRestResultShort": "{name} nimmt eine kurze Rast.",
-   "DND5E.ShortRestSelect": "Wähle Würfel",
-   "DND5E.Size": "Größe",
-   "DND5E.SizeGargantuan": "Gigantisch",
-   "DND5E.SizeGargantuanAbbr": "Gi",
-   "DND5E.SizeHuge": "Riesig",
-   "DND5E.SizeHugeAbbr": "Ri",
-   "DND5E.SizeLarge": "Gross",
-   "DND5E.SizeLargeAbbr": "Gr",
-   "DND5E.SizeMedium": "Mittelgross",
-   "DND5E.SizeMediumAbbr": "Mi",
-   "DND5E.SizeSmall": "Klein",
-   "DND5E.SizeSmallAbbr": "Ll",
-   "DND5E.SizeTiny": "Winzig",
-   "DND5E.SizeTinyAbbr": "Wi",
-   "DND5E.Skill": "Fertigkeit",
-   "DND5E.SkillAcr": "Akrobatik",
-   "DND5E.SkillAni": "Mit Tieren umgehen",
-   "DND5E.SkillArc": "Arkane Kunde",
-   "DND5E.SkillAth": "Athletik",
-   "DND5E.SkillBonusCheck": "Probenbonus",
-   "DND5E.SkillBonusPassive": "Passiver Bonus",
-   "DND5E.SkillBonuses": "Fertigkeitsboni",
-   "DND5E.SkillConfigurationHint": "Übung in Fertigkeit und Boni bearbeiten.",
-   "DND5E.SkillConfigure": "Fertigkeit bearbeiten",
-   "DND5E.SkillsConfig": "Fertigkeiten bearbeiten",
-   "DND5E.SkillConfigureTitle": "{skill} bearbeiten",
-   "DND5E.SkillDec": "Täuschen",
-   "DND5E.SkillGlobalBonusCheckHint": "Dieser Bonus gilt für alle Fertigkeitsproben dieses Akteurs.",
-   "DND5E.SkillHis": "Geschichte",
-   "DND5E.SkillIns": "Motiv erkennen",
-   "DND5E.SkillInv": "Nachforschungen",
-   "DND5E.SkillItm": "Einschüchtern",
-   "DND5E.SkillMed": "Heilkunde",
-   "DND5E.SkillModifierHint": "{skill}-Modifikator",
-   "DND5E.SkillNat": "Naturkunde",
-   "DND5E.SkillPassiveHint": "Passive {skill}",
-   "DND5E.SkillPassiveScore": "Passiver {skill}wert",
-   "DND5E.SkillPassiveSpecificHint": "Passive {ability} ({skill})",
-   "DND5E.SkillPassives": "Passive Fertigkeiten",
-   "DND5E.SkillPer": "Überzeugen",
-   "DND5E.SkillPrc": "Wahrnehmung",
-   "DND5E.SkillPrf": "Auftreten",
-   "DND5E.SkillPromptTitle": "{skill} Fertigkeitswurf",
-   "DND5E.SkillRel": "Religion",
-   "DND5E.SkillSlt": "Fingerfertigkeit",
-   "DND5E.SkillSte": "Heimlichkeit",
-   "DND5E.SkillSur": "Überlebenskunst",
-   "DND5E.Skills": "Fertigkeiten",
-   "DND5E.Skin": "Haut",
-   "DND5E.Skip": "Überspringen",
-   "DND5E.SOURCE": {
-    "FIELDS": {
-        "source": {
-            "label": "Quelle",
-            "book": {
-                "label": "Buch"
-            },
-            "custom": {
-                "label": "Eigenes Label"
-            },
-            "license": {
-                "label": "Lizenz"
-            },
-            "page": {
-                "label": "Seite/Abschnitt"
-            },
-            "revision": {
-                "label": "Revision"
-            },
-            "rules": {
-                "label": "Regelversion"
-            },
-            "uuid": {
-                "label": "Originalquelle"
-            }
-        }
-    },
-    "Action": {
-        "Configure": "Quelle Konfigurieren"
-    },
-    "Display": {
-        "Full": "{book} {page}",
-        "Page": "S. {page}"
-    }
-},
-   "DND5E.Special": "Spezial",
-   "DND5E.SpecialHint": "Spezialwerte durch Semikolons getrennt.",
-   "DND5E.SpecialTraits": "Spezielle Merkmale",
-   "DND5E.Species": {
-    "Label": "Spezies",
-    "Add": "Spezies Hinzufügen",
-    "Features": "Spezies Merkmal",
-    "Name": "Spezies Name"
-},
-   "DND5E.Speed": "Bewegungswert",
-   "DND5E.SpeedConditions": "Bewegungsbedingung",
-   "DND5E.SpeedSpecial": "Spez. Bewegungsart",
-   "DND5E.SpellAbility": "Zauberattribut",
-   "DND5E.SpellAbilitySet": "Festlegen als Primäres Zauberattribut",
-   "DND5E.SpellAdd": "Zauber hinzufügen",
-   "DND5E.SpellCantrip": "Zaubertrick",
-   "DND5E.SpellCastConsume": "Zauberplatz verbrauchen?",
-   "DND5E.SpellCastNoSlots": "Kein freier Zauberplatz um diesen Spruch zu wirken",
-   "DND5E.SpellCastNoSlotsLeft": "Du hast keine Verfügbaren Zauberplätze um {name} zu wirken!",
-   "DND5E.SpellCastTime": "Zauberzeit",
-   "DND5E.SpellCastUpcast": "Wirke auf Grad",
-   "DND5E.SpellCastingHeader": "Zauberwirken",
-   "DND5E.Spellcasting": "Zauberwirken",
-   "DND5E.SpellComponent": "Zauberkomponenten",
-   "DND5E.SpellComponents": "Zauber Komponenten",
-   "DND5E.SpellCreate": "Zauber erschaffen",
-   "DND5E.SpellDC": "Zauber SG",
-   "DND5E.SpellDetails": "Zauber Details",
-   "DND5E.SpellEffects": "Zauber Effekte",
-   "DND5E.SpellHeader": {
-       "Formula": "Formel",
-       "Range": "Reichweite",
-       "Roll": "Wurf",
-       "School": "Schule",
-       "Target": "Ziel",
-       "Time": "Zeit"
-   },
-   "DND5E.SpellLevel": "Zaubergrad",
-   "DND5E.SpellLevel0": "Zaubertrick",
-   "DND5E.SpellLevel1": "1. Grad",
-   "DND5E.SpellLevel2": "2. Grad",
-   "DND5E.SpellLevel3": "3. Grad",
-   "DND5E.SpellLevel4": "4. Grad",
-   "DND5E.SpellLevel5": "5. Grad",
-   "DND5E.SpellLevel6": "6. Grad",
-   "DND5E.SpellLevel7": "7. Grad",
-   "DND5E.SpellLevel8": "8. Grad",
-   "DND5E.SpellLevel9": "9. Grad",
-   "DND5E.SpellLevelPact": "Paktzauberplatz",
-   "DND5E.SpellLevelSlot": "{level} ({n} Plätze)",
-   "DND5E.SpellLevels": "Zaubergrade",
-   "DND5E.SpellMaterials": "Zaubermaterialien",
-   "DND5E.SpellMaterialsConsumed": "Material verbrauchen",
-   "DND5E.SpellMaterialsCost": "Materialkosten",
-   "DND5E.SpellMaterialsDescription": "Materialbeschreibung",
-   "DND5E.SpellMaterialsSupply": "Materialvorrat",
-   "DND5E.SpellName": "Zaubername",
-   "DND5E.SpellNone": "Nichts",
-   "DND5E.SpellPrepAlways": "Immer verfügbar",
-   "DND5E.SpellPrepAtWill": "Nach Belieben",
-   "DND5E.SpellPrepInnate": "Angeborenes Zauberwirken",
-   "DND5E.SpellPrepRitual": "Nur Rituale",
-   "DND5E.SpellPrepPrepared": "Vorbereitet",
-   "DND5E.SpellPreparation": "Zaubervorbereitung",
-   "DND5E.SpellSourceClass": "Quellenklasse",
-   "DND5E.SpellPrepared": "Vorbereitet",
-   "DND5E.SpellProgArt": "Artifizient",
-   "DND5E.SpellProgAvailable": "Verfügbare Plätze",
-   "DND5E.SpellProgFull": "Vollzauberer",
-   "DND5E.SpellProgHalf": "Halbzauberer",
-   "DND5E.SpellProgLeveled": "Stufenbasiertes Zaubern",
-   "DND5E.SpellProgOverride": "Überschreibe Plätze",
-   "DND5E.SpellProgPact": "Paktmagie",
-   "DND5E.SpellProgThird": "Drittelzauberer",
-   "DND5E.SpellProgression": "Zauberfortschritt",
-   "DND5E.SpellSchool": "Zauberschule",
-   "DND5E.SpellScroll": "Zauberspruchrolle",
-   "DND5E.SpellSlotExpended": "Verbrauchter Zauberplatz",
-   "DND5E.SpellSlotN.few": "{n}. Zauberplatz",
-   "DND5E.SpellSlotN.one": "{n}. Zauberplatz",
-   "DND5E.SpellSlotN.other": "{n}. Zauberplatz",
-   "DND5E.SpellSlotN.two": "{n}. Zauberplatz",
-   "DND5E.SpellSlotsConfig": "Zauberplätze Konfigurieren",
-   "DND5E.SpellSlotsN.few": "{n}. Grad Zauberplätze",
-   "DND5E.SpellSlotsN.one": "{n}. Grad Zauberplätze",
-   "DND5E.SpellSlotsN.other": "{n}. Grad Zauberplätze",
-   "DND5E.SpellSlotsN.two": "{n}. Grad Zauberplätze",
-   "DND5E.SpellSlotsPact": "Pakt-Zauberplätze",
-   "DND5E.SpellTag": "Zauber-Tag",
-   "DND5E.SpellTarget": "Zauberziel",
-   "DND5E.SpellUnprepared": "Unvorbereitet",
-   "DND5E.SpellUsage": "Zaubernutzung",
-   "DND5E.Spellbook": "Zauberbuch",
-   "DND5E.Spent": "Ausgegeben",
-   "DND5E.SpellcasterLevel": "Zauberwirkerstufe",
-   "DND5E.SpellcastingClass": "{class} Zauberwirken",
-   "DND5E.SpellsSearch": "Zauber durchsuchen",
-   "DND5E.StartingEquipment": {
-       "Title": "Startausrüstung",
-       "Action": {
-           "AddEntry": "Eintrag hinzufügen",
-           "Configure": "Startausrüstung konfigurieren",
-           "RemoveEntry": "Eintrag entfernen"
-       },
-       "Choice": {
-           "Armor": "Rüstung wählen",
-           "Focus": "Zauberfokus wählen",
-           "Tool": "Werkzeug wählen",
-           "Weapon": "Waffe wählen"
-       },
-       "DropHint": "Item hier ablegen zum verlinken",
-       "IfProficient": "Wenn geübt",
-       "Operator": {
-           "AND": "Alle aus…",
-           "OR": "Eins aus…"
-       },
-       "RequireProficiency": "Benötigt Übung",
-       "SpecificItem": "Spezifisches Item",
-       "Warning": {
-           "Depth": "Bei der Startausrüstung sind nur drei Verschachtelung erlaubt.",
-           "ItemTypeInvalid": "{type} Items können nicht zur Startausrüstung hinzugefügt werden."
-       },
-       "Wealth": {
-           "Label": "Startvermögen",
-           "Hint": "Formel in GM, die anstelle der Startausrüstung verwendet werden kann."
-       }
-   },
-   "DND5E.SubclassAdd": "Unterklasse Hinzufügen",
-   "DND5E.SubclassAssignmentError": "{class} hat schon eine Unterklasse. Bestehende Unterklasse '{subclass}' entfernen, bevor eine neue hinzugefügt wird.",
-   "DND5E.SubclassDuplicateError": "Unterklasse mit ID {identifier} existiert an diesem Akteur bereits.",
-   "DND5E.SubclassIdentifierHint": "Diese ID sollte der Oberklasse entsprechen, um sicherzustellen, dass beide richtig verknüpft sind.",
-   "DND5E.SubclassMismatchWarn": "Unterklasse {name} verfügt über keine Klasse, die zur ID '{class}' passt.",
-   "DND5E.SubclassName": "Name der Unterklasse",
-   "DND5E.Subtype": "Unterart",
-   "DND5E.SUMMON": {
-    "Title": "Beschwören",
-    "FIELDS": {
-        "bonuses": {
-            "ac": {
-                "label": "Bonus Rüstungsklasse",
-                "hint": "Bonus auf die Rüstungsklasse, die für die beschworene Kreatur festgelegt wurde, zusätzlich zu dem, was in ihrem Werteblock angegeben ist."
-            },
-            "attackDamage": {
-                "label": "Bonus Angriffsschaden",
-                "hint": "Zusätzlicher Schaden durch die Angriffe der Kreatur."
-            },
-            "hd": {
-                "label": "Bonus Trefferwürfel",
-                "hint": "Fügt der Kreatur zusätzliche Trefferwürfel hinzu, zusätzlich zu denen, die sich aus der TP-Formel in ihrem Werteblock ergeben. Kann nur bei der Beschwörung von NPC-Akteuren verwendet werden."
-            },
-            "healing": {
-                "label": "Bonus Heilung",
-                "hint": "Zusätzliche Heilung durch heilende Fähigkeiten."
-            },
-            "hp": {
-                "label": "Bonus Trefferpunkte",
-                "hint": "Der Kreatur wurden zusätzlich zu den Angaben in ihrem Werteblock weitere Trefferpunkte hinzugefügt."
-            },
-            "saveDamage": {
-                "label": "Bonus Rettungswurfschaden",
-                "hint": "Zusätzlicher Schaden, der durch die Fähigkeitene der Kreatur verursacht wird und Rettungswürfe erfordert."
-            }
-        },
-        "creatureSizes": {
-            "label": "Kreaturengröße",
-            "hint": "Beschworene Kreaturen und Toen werden auf diese Größe geändert. Wenn mehr als eine Größe ausgewählt wird, kann der Spieler beim Beschwören aus diesen Größen wählen."
-        },
-        "creatureTypes": {
-            "label": "Kreaturentyp",
-            "hint": "Die beschworene Kreatur wird in diesen Typ geändert. Wenn mehr als ein Typ ausgewählt ist, kann der Spieler beim Beschwören aus diesen Typen auswählen."
-        },
-        "match": {
-            "attacks": {
-                "label": "Angriffe Angleichen",
-                "hint": "Passt die Trefferwerte der Angriffe der beschworenen Kreatur an die des Beschwörers an."
-            },
-            "proficiency": {
-                "label": "Übungen angleichen",
-                "hint": "Passt die Übungen der beschworenen Kreatur an die des Beschwörers an."
-            },
-            "saves": {
-                "label": "Rettungswürfe angleichen",
-                "hint": "Passt die Rettungswürfe SGs für die Fähigkeiten der beschworenen Kreatur an die des Beschwörers an."
-            }
-        },
-        "profiles": {
-            "label": "Beschwörungs Profil",
-            "FIELDS": {
-                "count": {
-                    "label": "Anzahl"
-                },
-                "cr": {
-                    "label": "Herausforderungsgrad",
-                    "abbr": "HG",
-                    "hint": "Maximaler HG der beschworenen Kreatur."
-                },
-                "level": {
-                    "label": "Stufengrenze",
-                    "hint": "Stufenbereich, der für die Verwendung dieses Profils erforderlich ist.",
-                    "max": {
-                        "label": "Maximale Stufe"
-                    },
-                    "min": {
-                        "label": "Minimale Stufe"
-                    }
-                },
-                "name": {
-                    "label": "Anzeigename",
-                    "hint": "Name des Profils, der im Nutzungsdialog angezeigt wird."
-                },
-                "types": {
-                    "label": "Kreaturentyp",
-                    "hint": "Liste der Kreaturentypen, aus denen die beschworene Kreatur ausgewählt werden kann."
-                },
-                "uuid": {
-                    "label": "Verlinkte Kreatur"
-                }
-            }
-        },
-        "summon": {
-            "label": "Beschwörung Details",
-           "identifier": {
-                "label": "Klassen-ID",
-                "hint": "ID, die verwendet wird, um zu bestimmen, ob die Charakterstufe oder eine bestimmte Klassenstufe für die Begrenzung der Verzauberungsstufe verwendet werden soll."
-            },
-            "mode": {
-                "label": "Modus",
-                "hint": "Legt fest, wie die Kreaturen, die beschworen werden sollen, spezifiziert werden.",
-                "CR": "Durch Herausforderungsgrad & Typ",
-                "Direct": "Durch direkte Verlinkung"
-            },
-            "prompt": {
-                "label": "Beschwörungsabfrage",
-                "hint": "Wenn nicht aktiviert, wird die Abfrage zum platzieren einer Beschwörung unterdrückt. Die Spieler können weiterhin über die Chatkarte beschwören."
-            }
-        }
-    },
-    "SECTIONS": {
-        "Changes": "Änderungen",
-        "Profiles": "Profile",
-        "Summoning": "Beschwörung"
-    },
-    "Action": {
-        "Place": "Beschwörungen Platzieren",
-        "Summon": "Beschwören",
-        "View": "Beschwörung Anzeigen"
-    },
-    "CreatureChanges": {
-        "Label": "Kreatur anpassungen",
-        "Hint": "Anpassungen, die an der beschworenen Kreatur vorgenommen werden. Alle @ Referenzen, die in den folgenden Formeln verwendet werden, basieren auf den Werten des Beschwörers. Die Werte beschworener Kreaturen können mit @summon abgerufen werden (z. B. @summon.attributes.hd.max, um die Trefferwürfelzahl der Kreatur abzurufen)."
-    },
-    "ItemChanges": {
-        "Label": "Item Anpassungen",
-        "Hint": "Anpassungen an den Items der beschworenen Kreatur."
-    },
-    "Profile": {
-        "Label": "Beschwörungs Profil",
-        "Action": {
-            "Create": "Erstelle Profil",
-            "Delete": "Entferne Profil"
-        },
-        "ChallengeRatingLabel": "Herausforderungsgrad von {cr} oder niedriger",
-        "DropHint": "Kreatur hier ablegen",
-        "Empty": "Klicke den <i class=\"fas fa-plus\"></i> Knopf oben um ein Profil zu erstellen.",
-        "EmptyDrop": "Klicke den <i class=\"fas fa-plus\"></i> Knopf oben um ein Profil zu erstellen oder lege hier eine Kreatur zum beschwören ab"
-    },
-    "Warning": {
-        "CreateActor": "Sie müssen über die Berechtigung 'Neue Akteure erstellen' verfügen, um direkt aus einem Kompendium beschwören zu können.",
-        "CRV11": "Beschwörungen basierend auf dem Herausforderungsgrad der Kreaturen, funktioniert nur in Foundry V12 oder höher.",
-        "NoActor": "Akteur mit der UUID '{uuid}' kann nicht gefunden werden, um zu beschwören.",
-        "NoOwnership": "Du musst Eigentümer von '{Akteur}' sein, um ihn beschwören zu können.",
-        "NoProfile": "Das Beschwörungsprofil {profileId} für '{item}' konnte nicht gefunden werden.",
-        "Wildcard": "Sie müssen über die Berechtigung 'Dateien durchsuchen' verfügen, um Kreaturen mit Platzhalterbildern zu beschwören."
-    }
-},
-   "DND5E.Summoning": {
-       "Label": "Beschwörung",
-       "Action": {
-           "Add": "Profil hinzufügen",
-           "Configure": "Beschwörungen konfigurieren",
-           "Place": "Beschwörungen platzieren",
-           "Remove": "Profil entfernen",
-           "Summon": "Beschwören",
-           "View": "Beschwörung ansehen"
-       },
-       "Bonuses": {
-           "ArmorClass": {
-               "Label": "Bonus-Rüstungsklasse",
-               "Hint": "Bonus auf die Rüstungsklasse der beschworenen Kreatur zusätzlich zu den Angaben in ihrem Statblock."
-           },
-           "Attack": {
-               "Label": "Bonus-Angriffsschaden",
-               "Hint": "Zusätzlicher Schaden, der durch die Angriffe der Kreatur verursacht wird."
-           },
-           "Healing": {
-               "Label": "Bonus-Heilung",
-               "Hint": "Zusätzliche Heilung durch Heilfähigkeiten."
-           },
-           "HitDice": {
-               "Label": "Bonus-Trefferwürfel",
-               "Hint": "Zusätzliche Trefferwürfel, die der Kreatur zusätzlich zu den Werten aus der TP-Formel in ihrem Statblock hinzugefügt werden. Kann nur bei der Beschwörung von NPC-Akteuren verwendet werden."
-           },
-           "HitPoints": {
-               "Label": "Bonus-Trefferpunkte",
-               "Hint": "Zusätzliche Trefferpunkte, die der Kreatur zusätzlich zu den in ihrem Statblock angegebenen hinzugefügt werden."
-           },
-           "Saves": {
-               "Label": "Bonus-Rettungswurfschaden",
-               "Hint": "zusätzlicher Schaden, der durch die Fähigkeiten der Kreatur verursacht wird, die Rettungswürfe erfordern."
-           }
-       },
-       "Configuration": "Beschwörung konfigurieren",
-       "Count": {
-           "Label": "Anzahl"
-       },
-       "CreatureChanges": {
-           "Label": "Kreatur anpassungen",
-           "Hint": "Anpassungen, die an der beschworenen Kreatur vorgenommen werden. Alle @ Referenzen, die in den folgenden Formeln verwendet werden, basieren auf den Werten des Beschwörers."
-       },
-       "CreatureSizes": {
-           "Label": "Größe der Kreaturen",
-           "Hint": "Die beschworene Kreatur und der Token werden in diese Größe geändert. Wenn mehr als eine Größe ausgewählt wurde, kann der Spieler bei der Beschwörung zwischen diesen Größen wählen."
-       },
-       "CreatureTypes": {
-           "Label": "Kreaturentypen",
-           "Hint": "Die beschworene Kreatur wird in diesen Typ umgewandelt. Wenn mehr als ein Typ ausgewählt wurde, kann der Spieler bei der Beschwörung zwischen diesen Typen wählen."
-       },
-       "DisplayName": "Anzeigename",
-       "DropHint": "Kreatur hier ablegen",
-       "ItemChanges": {
-           "Label": "Item Anpassungen",
-           "Hint": "Anpassungen an den Items der beschworenen Kreatur."
-       },
-       "Level": {
-           "Hint": "Stufenbereich, der für die Verwendung dieses Profils erforderlich ist.",
-           "IdentifierHint": "ID, mit der festgelegt wird, ob die Charakterstufe oder eine bestimmte Klassenstufe für die Begrenzung des Profils verwendet werden soll."
-       },
-       "Match": {
-           "Attacks": {
-               "Label": "Angriffe angleichen",
-               "Hint": "Passt die Trefferwerte der Angriffe der beschworenen Kreatur an die des Beschwörers an."
-           },
-           "Proficiency": {
-               "Label": "Übungen angleichen",
-               "Hint": "Passt die Übungen der beschworenen Kreatur an die des Beschwörers an."
-           },
-           "Saves": {
-               "Label": "Rettungswürfe angleichen",
-               "Hint": "Passt die Rettungswürfe SGs für die Fähigkeiten der beschworenen Kreatur an die des Beschwörers an."
-           }
-       },
-       "Mode": {
-           "Label": "Modus",
-           "Hint": "Legt fest, wie die Kreaturen, die beschworen werden sollen, spezifiziert werden.",
-           "CR": "Nach Herausforderungsgrad und Typ",
-           "Direct": "Mit direktem Link"
-       },
-       "Profile": {
-           "Label": "Beschwörungs Profil",
-           "LabelPl": "Beschwörungen Profile",
-           "ChallengeRatingLabel": "Herausforderungsgrad von {cr} oder niedriger",
-           "Empty": "Klicken Sie oben, um ein Profil hinzuzufügen.",
-           "EmptyDrop": "Klicken Sie oben, um ein Profil hinzuzufügen, oder legen sie eine Kreatur ab."
-       },
-       "Prompt": {
-           "Label": "Beschwörungsabfrage",
-           "Hint": "Wenn nicht aktiviert, wird die Abfrage zum platzieren einer Beschwörung unterdrückt. Die Spieler können weiterhin über die Chatkarte beschwören."
-       },
-       "Warning": {
-           "CreateActor": "Sie müssen über die Berechtigung 'Neue Akteure erstellen' verfügen, um direkt aus einem Kompendium beschwören zu können.",
-           "CRV11": "Beschwörungen basierend auf dem Herausforderungsgrad der Kreaturen, funktioniert nur in Foundry V12 oder höher.",
-           "NoActor": "Akteur mit der UUID '{uuid}' kann nicht gefunden werden, um zu beschwören.",
-           "NoOwnership": "Du musst Eigentümer von '{Akteur}' sein, um ihn beschwören zu können.",
-           "NoProfile": "Das Beschwörungsprofil {profileId} für '{item}' konnte nicht gefunden werden.",
-           "Wildcard": "Sie müssen über die Berechtigung 'Dateien durchsuchen' verfügen, um Kreaturen mit Platzhalterbildern zu beschwören."
-       }
-   },
-   "DND5E.Supply": "Versorgung",
-   "DND5E.Suppressed": "Unterdrückt",
-   "DND5E.TARGET": {
-    "FIELDS": {
-        "target": {
-            "label": "Ziele",
-            "affects": {
-                "label": "Betroffene Ziele",
-                "choice": {
-                    "label": "Wähle Ziele",
-                    "hint": "Kann der Benutzer bei der Auswahl eines Bereichs entscheiden, wer davon betroffen ist?"
-                },
-                "count": {
-                    "label": "Anzahl Ziele",
-                    "hint": "Anzahl der einzelnen Ziele, die betroffen sein können."
-                },
-                "special": {
-                    "label": "Spezielle Ziele",
-                    "hint": "Beschreibung für jede spezielle Ziel."
+                "label": "Aktivierung",
+                "override": {
+                    "hint": "Verwende diese Aktivierungswerte anstelle der Werte des Items, wenn du diese Aktivität verwendest.",
+                    "label": "Aktivierung überschreiben"
                 },
                 "type": {
-                    "label": "Zielart",
-                    "hint": "Art der Ziele, die betroffen sein können (z. B. Kreaturen, Objekte, Räume)."
-                }
-            },
-            "override": {
-                "label": "Überschreibe Ziel",
-                "hint": "Verwende diese Zielwerte anstelle der Items, wenn du diese Aktivität verwendest."
-            },
-            "prompt": {
-                "label": "Vorlagenabfrage für Messschablone",
-                "hint": "Sollte der Spieler aufgefordert werden, eine Messschablone zu platzieren? Spieler können weiterhin Vorlagen von der Chat-Karte platzieren, wenn die Aufforderung deaktiviert ist."
-            },
-            "template": {
-                "label": "Wirkungsbereich",
-                "contiguous": {
-                    "label": "Angrenzende Bereiche",
-                    "hint": "Müssen alle geschaffenen Bereiche miteinander verbunden sein?"
+                    "hint": "Aktivierungstyp (z.B. Aktion, Legendäre Aktion, Minuten)",
+                    "label": "Aktivierungskosten"
                 },
-                "count": {
-                    "label": "Anzahl Bereiche",
-                    "hint": "Anzahl der verschiedenen Bereiche, die gezielt angewählt werden können."
-                },
-                "height": {
-                    "label": "Bereichshöhe",
-                    "hint": "Height of a cylinder affected if applicable."
-                },
-                "size": {
-                    "label": "Bereichsgröße",
-                    "hint": "Größe des Wirkungsbereichs auf seiner Hauptachse."
-                },
-                "type": {
-                    "label": "Bereichstyp",
-                    "hint": "Art des Zielbereichs."
-                },
-                "units": {
-                    "label": "Bereicheinheit",
-                    "hint": "Einheiten zur Messung der Größe von Wirkungsbereichen."
-                },
-                "width": {
-                    "label": "Bereichsbreite",
-                    "hint": "Breite einer Linie wenn verfügbar."
+                "value": {
+                    "hint": "Skalarwert, der mit der Aktivierung verbunden ist.",
+                    "label": "Aktivierungswert"
                 }
             }
         }
     },
-    "Action": {
-        "PlaceTemplate": "Platziere Messschablone"
-    },
-    "Warning": {
-        "PlaceTemplate": "Die Messschablone konnte nicht platziert werden."
-    }
-},
-   "DND5E.TMP": "TMP",
-   "DND5E.Target": "Ziel",
-   "DND5E.TargetPl": "Ziele",
-   "DND5E.TargetAlly": "Verbündeter",
-   "DND5E.TargetAny": "Beliebig",
-   "DND5E.TargetCircle": "Kreis",
-   "DND5E.TargetCone": "Kegel",
-   "DND5E.TargetCreature": "Kreatur",
-   "DND5E.TargetCreatureOrObject": "Kreatur oder Objekt",
-   "DND5E.TargetCube": "Würfel",
-   "DND5E.TargetCylinder": "Zylinder",
-   "DND5E.TargetEnemy": "Feind",
-   "DND5E.TargetEvery": "Jede",
-   "DND5E.TargetLine": "Linie",
-   "DND5E.TargetObject": "Objekt",
-   "DND5E.TargetRadius": "Radius",
-   "DND5E.TargetRadiusLegacy": "Radius",
-   "DND5E.TargetSelf": "Selbst",
-   "DND5E.TargetSpace": "Raum",
-   "DND5E.TargetSphere": "Kugel",
-   "DND5E.TargetSquare": "Quadrat",
-   "DND5E.TargetType": "Zielart",
-   "DND5E.TargetTypeArea": "Bereich",
-   "DND5E.TargetTypeIndividual": "Gezielt",
-   "DND5E.TargetUnits": "Bereichseffekt-Einheit",
-   "DND5E.TargetValue": "Ziellänge oder Anzahl",
-   "DND5E.TargetWall": "Wand",
-   "DND5E.TargetWidth": "Linienbreite",
-   "DND5E.TargetWilling": "Bereitwillige Kreatur",
-   "DND5E.Temp": "Temp",
-   "DND5E.TemplatePrompt": "Vorlagenabfrage",
-   "DND5E.TemplatePromptTooltip": "Wenn nicht aktiviert, wird die Abfrage zum platzieren einer Vorlage unterdrückt.",
-   "DND5E.Threshold": "Schwellenwert",
-   "DND5E.TimeDay": "Tage",
-   "DND5E.TimeDayAbbr": "t",
-   "DND5E.TimeDisp": "Bis der Zauber gebannt wird",
-   "DND5E.TimeDispTrig": "Bis der Zauber gebannt oder ausgelöst wird",
-   "DND5E.TimeHour": "Stunden",
-   "DND5E.TimeHourAbbr": "h",
-   "DND5E.TimeInst": "Sofort",
-   "DND5E.TimeMinute": "Minuten",
-   "DND5E.TimeMinuteAbbr": "m",
-   "DND5E.TimeMonth": "Monate",
-   "DND5E.TimePerm": "Permanent",
-   "DND5E.TimeRound": "Runden",
-   "DND5E.TimeTurn": "Züge",
-   "DND5E.TimeYear": "Jahre",
-   "DND5E.ToHit": "Trefferbonus",
-   "DND5E.Tokens": {
-       "NoneSelected": "Kein Token ausgewählt",
-       "NoneTargeted": "Kein Token anvisiert",
-       "Selected": "Ausgewählt",
-       "Targeted": "Anvisiert"
-   },
-   "DND5E.TokenRings": {
-       "BackgroundColor": "Hintergrundfarbe",
-       "Effects": {
-           "Label": "Effekte",
-           "BackgroundWave": "Hintergrundwelle",
-           "RingGradient": "Ring Farbverlauf",
-           "RingPulse": "Ring-Puls"
-       },
-       "Enabled": "Dynamischen Ring verwenden",
-       "RingColor": "Ringfarbe",
-       "ScaleCorrection": "Skala Korrektur",
-       "Subject": {
-           "Label": "Subjekt Pfad",
-           "Hint": "Geben Sie explizit einen Pfad für das über dem dynamischen Token-Ring platzierte Bildmaterial an. Wird kein Pfad angegeben, so wird versucht, das Bildmotiv durch Hinzufügen von \"-subject\" am Ende des normalen Pfads für das Token-Bild zu ermitteln."
-       },
-       "Title": "Dynamischer Ring"
-   },
-   "DND5E.ToggleDescription": "Beschreibung umschalten",
-   "DND5E.ToolArtisans": "Handwerkerausrüstung",
-   "DND5E.ToolBonuses": "Werkzeugboni",
-   "DND5E.ToolCheck": "Werkzeugprobe",
-   "DND5E.ToolConfigure": "Übung mit Werkzeug bearbeiten",
-   "DND5E.ToolDisguiseKit": "Verkleidungsausrüstung",
-   "DND5E.ToolForgeryKit": "Fälscherausrüstung",
-   "DND5E.ToolGamingSet": "Spiel",
-   "DND5E.ToolHerbalismKit": "Kräuterkundeausrüstung",
-   "DND5E.ToolMusicalInstrument": "Musikinstrument",
-   "DND5E.ToolNavigators": "Navigationswerkzeuge",
-   "DND5E.ToolPoisonersKit": "Giftmischerausrüstung",
-   "DND5E.ToolPromptTitle": "{tool}-Probe",
-   "DND5E.ToolThieves": "Diebeswerkzeug",
-   "DND5E.ToolVehicle": "Fahrzeug",
-   "DND5E.TraitAll": "Alle {category}",
-   "DND5E.TraitArmorLegacyPlural.one": "Übung mit Rüstung",
-   "DND5E.TraitArmorLegacyPlural.other": "Übung mit Rüstungen",
-   "DND5E.TraitArmorLegacyProf": "Übung mit Rüstung",
-   "DND5E.TraitArmorPlural.one": "Übung mit Rüstung",
-   "DND5E.TraitArmorPlural.other": "Übung mit Rüstungen",
-   "DND5E.TraitArmorProf": "Übung mit Rüstung",
-   "DND5E.TraitCIPlural.one": "Zustandsimmunität",
-   "DND5E.TraitCIPlural.other": "Zustandsimmunitäten",
-   "DND5E.TraitConfig": "{trait} bearbeiten",
-   "DND5E.TraitConfigChooseAnyCounted": "jede {count} {type}",
-   "DND5E.TraitConfigChooseAnyUncounted": "jede {type}",
-   "DND5E.TraitConfigChooseList": "{count} aus {list}",
-   "DND5E.TraitConfigChooseOther": "{count} andere {type}",
-   "DND5E.TraitConfigChooseWrapper": "Wähle {choices}",
-   "DND5E.TraitDIPlural.one": "Schadensimmunität",
-   "DND5E.TraitDIPlural.other": "Schadensimmunitäten",
-   "DND5E.TraitDRPlural.one": "Schadensresistenz",
-   "DND5E.TraitDRPlural.other": "Schadensresistenzen",
-   "DND5E.TraitDVPlural.one": "Schadensanfälligkeit",
-   "DND5E.TraitDVPlural.other": "Schadensanfälligkeiten",
-   "DND5E.TraitGenericPlural.one": "Merkmal",
-   "DND5E.TraitGenericPlural.other": "Merkmale",
-   "DND5E.TraitLanguagesPlural.one": "Sprache",
-   "DND5E.TraitLanguagesPlural.other": "Sprachen",
-   "DND5E.TraitSave": "Speichern",
-   "DND5E.TraitSavesPlural.one": "Übung mit Rettungswurf",
-   "DND5E.TraitSavesPlural.other": "Übung mit Rettungswürfen",
-   "DND5E.TraitSelectorSpecial": "Spezial (durch Semikolon getrennt)",
-   "DND5E.TraitSkillsPlural.one": "Übung in Fertigkeit",
-   "DND5E.TraitSkillsPlural.other": "Übung in Fertigkeiten",
-   "DND5E.TraitToolPlural.one": "Übung mit Werkzeug",
-   "DND5E.TraitToolPlural.other": "Übung mit Werkzeugen",
-   "DND5E.TraitToolProf": "Übung mit Werkzeug",
-   "DND5E.TraitWeaponPlural.one": "Übung mit Waffe",
-   "DND5E.TraitWeaponPlural.other": "Übung mit Waffen",
-   "DND5E.TraitWeaponProf": "Übung mit Waffen",
-   "DND5E.Traits": "Eigenschaften",
-   "DND5E.TraitsChosen": "Gewählte Eigenschaften",
-   "DND5E.Trigger": "Auslöser",
-   "DND5E.Type": "Typ",
-   "DND5E.Uncrewed": "Unbemannt",
-   "DND5E.Unequipped": "Nicht angelegt",
-   "DND5E.Unidentified.DefaultName": "Unidentifiziert: {name}",
-   "DND5E.Unidentified.Notice": "Du musst das Item identifizieren um die details zu erfahren.",
-   "DND5E.Unidentified.Title": "Unidentifiziert",
-   "DND5E.Unidentified.Value": "???",
-   "DND5E.Unknown": "Unbekannt",
-   "DND5E.Unlimited": "Unbegrenzt",
-   "DND5E.USAGE": {
-    "SECTION": {
-        "Consumption": "Verbrauch",
-        "Creation": "Erstellen",
-        "Scaling": "Skalierung"
-    }
-},
-   "DND5E.Usage": "Nutzung",
-   "DND5E.Use": "benutzen",
-   "DND5E.UseItem": "Use {item}",
-   "DND5E.Uses": "Nutzungen",
-   "DND5E.UsesAvailable": "Verbleibende  Nutzungen",
-   "DND5E.UsesMax": "Maximale Nutzungen",
-   "DND5E.UsesPeriod": "Aufladungszeit",
-   "DND5E.UsesPeriods": {
-       "AtWill": "Nach Belieben",
-       "Charges": "Aufladungen",
-       "ChargesAbbreviation": "Aufladungen",
-       "Dawn": "Morgengrauen",
-       "DawnAbbreviation": "Morgengrauen",
-       "Day": "Tag",
-       "DayAbbreviation": "Tag",
-       "Dusk": "Dämmerung",
-       "DuskAbbreviation": "Dämmerung",
-       "Lr": "Lange Rast",
-       "LrAbbreviation": "LR",
-       "Never": "Niemals",
-       "Sr": "Kurze Rast",
-       "SrAbbreviation": "KR"
-   },
-   "DND5E.USES": {
-    "FIELDS": {
-        "uses": {
-            "label": "Nutzungen",
-            "max": {
-                "label": "Maximale Nutzungen",
-                "hint": "Formel für die maximale Anzahl von Nutzungen"
-            },
-            "recovery": {
-                "label": "Nutzung Wiederherstellung",
-                "hint": "Wiederherstellungsprofile für dies Nutzungen dieser Aktivität",
-                "FIELDS": {
-                    "period": {
-                        "label": "Wiederherstellungsperiode",
-                        "hint": "Zeitpunkt, zu dem diese Wiedederherstellung eintreten wird."
-                    },
-                    "type": {
-                        "label": "Wiederherstellungstyp",
-                        "hint": "Wie Nutzungen wiederhergestellt werden."
-                    },
-                    "formula": {
-                        "label": "Wiederherstellungsformel",
-                        "hint": "Formel zur Bestimmung der Anzahl der wiederhergestellten Nutzungen."
-                    }
-                }
-            },
-            "spent": {
-                "label": "Verbrauche Nutzung",
-                "hint": "Anzahl der Nutzungen die verbraucht werden."
-            }
-        }
-    },
-    "Recovery": {
+    "DND5E.ACTIVITY": {
         "Action": {
-            "Create": "Erstelle Wiederherstellungsprofil",
-            "Delete": "Entferne Wiederherstellungsprofil"
+            "Create": "Erstelle Aktivität",
+            "Delete": "Entferne Aktivität"
         },
-        "Recharge": {
-            "Label": "Wiederaufladen",
-            "Range": "Wiederaufladen {range}"
-        },
-        "Type": {
-            "Formula": "Eigene Formel",
-            "LoseAll": "Alle Nutzungen verlieren",
-            "RecoverAll": "Alle Nutzungen Wiederherstellen"
-        }
-    }
-},
-"DND5E.UTILITY": {
-    "Title": "Utility",
-    "FIELDS": {
-        "roll": {
-            "label": "Utility Wurf",
-            "formula": {
-                "label": "Wurf Formel",
-                "hint": "Formel für einen beliebigen Wurf."
+        "FIELDS": {
+            "description": {
+                "chatFlavor": {
+                    "hint": "Zusätzlicher Text, der in der Aktivierungs-Chatnachricht angezeigt wird.",
+                    "label": "Chat Flavortext"
+                },
+                "label": "Beschreibung"
+            },
+            "effects": {
+                "label": "Effekt anwenden"
+            },
+            "img": {
+                "label": "Icon"
             },
             "name": {
-                "label": "Wurf Beschriftung",
-                "hint": "Beschiftung für den Wurfknopf"
+                "label": "Name"
+            }
+        },
+        "SECTIONS": {
+            "Activation": "Aktivierung",
+            "Behavior": "Verhalten",
+            "Effect": "Effekt",
+            "Identity": "Identität",
+            "Time": "Zeit"
+        },
+        "Title": {
+            "one": "Aktivität",
+            "other": "Aktivitäten"
+        }
+    },
+    "DND5E.ADVANCEMENT": {
+        "AbilityScoreImprovement": {
+            "CapDisplay": {
+                "one": "Maximal {points} Punkte pro Attribut",
+                "other": "Maximal {points} Punkte pro Wert"
             },
-            "prompt": {
-                "label": "Utility Wurf Abfrage",
-                "hint": "Sollte das Dialogfeld „Wurfkonfiguration“ beim Würfeln angezeigt werden?"
+            "FIELDS": {
+                "cap": {
+                    "hint": "Maximale Anzahl von Punkten, die ein Spieler einem einzelnen Attribut zuordnen kann.",
+                    "label": "Punktobergrenze"
+                },
+                "fixed": {
+                    "hint": "Attribute, die um einen festen Wert erhöht werden und während des Vorgangs nicht manuell erhöht werden können.",
+                    "label": "Feste Erhöhung"
+                },
+                "locked": {
+                    "hint": "Attributswert kann nicht erhöht werden.",
+                    "label": "Gesperrt"
+                },
+                "points": {
+                    "decrease": "Punkte verringern",
+                    "hint": "Anzahl der Punkte, die einem freigeschalteten Attributswert zugewiesen werden können.",
+                    "increase": "Punkte erhöhen",
+                    "label": "Punkte"
+                }
             },
-            "visible": {
-                "label": "Sichtbar für Alle",
-                "hint": "Soll der Wurfknopf für alle Spieler sichtbar sein?"
+            "Feat": {
+                "Hint": "Talent hierher ziehen um es statt einer Erhöhung der Attributswerte zu wählen."
+            },
+            "Hint": "Erlaubt dem Spieler, einen oder mehrere Attributswerte zu erhöhen oder ein optionales Talent zu wählen.",
+            "LockedHint": "Werte sind nicht veränderbar, wenn ein Talent gewählt wurde.",
+            "PointsRemaining": {
+                "one": "{points} Punkt verbleibend",
+                "other": "{points} Punkte verbleibend"
+            },
+            "Title": "Attributswerterhöhung",
+            "Warning": {
+                "Level": "Muss mindestens Stufe {Stufe} sein, um dieses Merkmal zu erhalten.",
+                "Type": "Nur Merkmale vom Typ \"Talent\" können gewählt werden."
+            }
+        },
+        "SPELLCONFIG": {
+            "FIELDS": {
+                "uses": {
+                    "requireSlot": {
+                        "hint": "Erfordert einen Zauberplatz, der ausgegeben werden muss, wenn die Limitierte Nutzungen genutzt werden. Wenn das Kästchen nicht markiert ist, handelt es sich um zusätzliche kostenlose Verwendungen, die keinen Platz verbrauchen.",
+                        "label": "Benötigt Zauberplatz"
+                    }
+                }
+            },
+            "FreeCasting": "Kostenloses Zauberwirken"
+        },
+        "Subclass": {
+            "FlowHint": "Wähle eine Unterklasse im Merkmale Reiter nachdem der Stufenaufstieg abgeschlossen ist.",
+            "Hint": "Gib an, auf welcher Stufe diese Klasse ihre Unterklasse erhält.",
+            "Title": "Unterklasse"
+        }
+    },
+    "DND5E.ATTACK": {
+        "Classification": {
+            "Spell": "Zauber",
+            "Unarmed": "Waffenlos",
+            "Weapon": "Waffe"
+        },
+        "FIELDS": {
+            "attack": {
+                "ability": {
+                    "hint": "Attribut, as für den Angriff und die Bestimmung des Schadens verwendet wird. Verfügbar mit @mod in Formeln.",
+                    "label": "Angriffsattribut"
+                },
+                "bonus": {
+                    "hint": "Bonus zum Angriffswurf für den Angriff hinzugefügt.",
+                    "label": "Auf Treffer Bonus"
+                },
+                "critical": {
+                    "threshold": {
+                        "hint": "Minimum Wert auf dem W20, der benötigt wird, um einen Kritischen Treffer zu erzielen.",
+                        "label": "Kritischer Schwellwert"
+                    }
+                },
+                "flat": {
+                    "hint": "Ignoriere den Attributsmodifikator, die Übung und alle anderen Boni des Akteurs und verwende nur den durch die Aktivität definierten Bonus, wenn du den Treffer berechnest.",
+                    "label": "Pauschal auf Treffer"
+                },
+                "label": "Angriffs-Details",
+                "type": {
+                    "classification": {
+                        "hint": "Handelt es sich um einen waffenlosen, einen Waffen- oder einen Zauberangriff?",
+                        "label": "Angriffsklassifizierung"
+                    },
+                    "label": "Angriffszyp",
+                    "value": {
+                        "hint": "Handelt es sich um einen Nah- oder Fernkampfangriff?",
+                        "label": "Angriffstyp"
+                    }
+                }
+            },
+            "damage": {
+                "critical": {
+                    "bonus": {
+                        "hint": "Zusätzlicher Schaden der zugefügt wird, wenn ein kritischer Treffer gewürfelt wird. Wird zum Grundschaden oder zum ersten Teil des Schadens addiert.",
+                        "label": "Zusätzlicher Kritischer Schaden"
+                    }
+                },
+                "includeBase": {
+                    "hint": "Inkludiere den Grundschaden des Items mit allen zusätzliche Schadensbestandteilen",
+                    "label": "Grundschaden inkludieren"
+                },
+                "label": "Angriffsschaden",
+                "parts": {
+                    "hint": "Individuelle Schadensbestandteile die in den Wurf inkludiert werden.",
+                    "label": "Schadensbestandteile"
+                }
+            }
+        },
+        "Mode": {
+            "Label": "Angriffsmodus",
+            "Offhand": "Nebenhand",
+            "OneHanded": "Einhändig",
+            "Thrown": "Wurfwaffe",
+            "ThrownOffhand": "Nebenhand Wurfwaffe",
+            "TwoHanded": "Zweihändig"
+        },
+        "Title": {
+            "one": "Angriff",
+            "other": "Angriffe"
+        },
+        "Type": {
+            "Melee": "Nahkampf",
+            "Ranged": "Fernkampf"
+        },
+        "Warning": {
+            "NoQuantity": "Versuch, mit einer Waffe mit einer Menge von Null anzugreifen."
+        }
+    },
+    "DND5E.AbbreviationCR": "HG",
+    "DND5E.AbbreviationConc": "Konz.",
+    "DND5E.AbbreviationDC": "SG",
+    "DND5E.AbbreviationKg": "kg",
+    "DND5E.AbbreviationLR": "LR",
+    "DND5E.AbbreviationLbs": "Pf.",
+    "DND5E.AbbreviationLevel": "St.",
+    "DND5E.AbbreviationSR": "SR",
+    "DND5E.Abilities": "Attribute",
+    "DND5E.Ability": "Attribut",
+    "DND5E.AbilityBonuses": "Attributsboni",
+    "DND5E.AbilityCha": "Charisma",
+    "DND5E.AbilityChaAbbr": "Cha",
+    "DND5E.AbilityCheckBonus": "Probenbonus",
+    "DND5E.AbilityCheckConfigurationHint": "Probenboni bearbeiten.",
+    "DND5E.AbilityCheckConfigure": "{ability} Fähigkeitsproben",
+    "DND5E.AbilityCheckGlobalBonusHint": "Dieser Bonus gilt für alle Attributswürfe dieses Akteurs.",
+    "DND5E.AbilityCon": "Konstitution",
+    "DND5E.AbilityConAbbr": "Kon",
+    "DND5E.AbilityConfigurationHint": "Übung für Rettungswürfe und Boni für Rettungswürfe und Proben konfigurieren.",
+    "DND5E.AbilityConfigure": "Fähigkeits- und Rettungswürfe bearbeiten",
+    "DND5E.AbilityConfigureTitle": "{ability} Rettungswürfe und Proben bearbeiten",
+    "DND5E.AbilityDex": "Geschicklichkeit",
+    "DND5E.AbilityDexAbbr": "Ges",
+    "DND5E.AbilityHon": "Ehre",
+    "DND5E.AbilityHonAbbr": "Ehr",
+    "DND5E.AbilityInt": "Intelligenz",
+    "DND5E.AbilityIntAbbr": "Int",
+    "DND5E.AbilityModifier": "Attributsmodifikator",
+    "DND5E.AbilityPromptText": "Welche Art von {ability} Wurf?",
+    "DND5E.AbilityPromptTitle": "{ability} Attributswurf",
+    "DND5E.AbilitySan": "Geistige Gesundheit",
+    "DND5E.AbilitySanAbbr": "Ges",
+    "DND5E.AbilitySaveConfigure": "{ability} Rettungswürfe",
+    "DND5E.AbilityScore": "Attributswert",
+    "DND5E.AbilityScoreL": "{ability} Wert",
+    "DND5E.AbilityScoreMax": "Maximaler Attributswert",
+    "DND5E.AbilityScoreMaxShort": "Maximal",
+    "DND5E.AbilityScorePl": "Attributswerte",
+    "DND5E.AbilityScoreShort": "Wert",
+    "DND5E.AbilityStr": "Stärke",
+    "DND5E.AbilityStrAbbr": "Stä",
+    "DND5E.AbilityUseCast": "Zauber wirken",
+    "DND5E.AbilityUseChargedHint": "{type} ist aufgeladen und bereit zur Verwendung!",
+    "DND5E.AbilityUseChargesLabel": "{value} Ladungen",
+    "DND5E.AbilityUseConfig": "Nutzungen bearbeiten",
+    "DND5E.AbilityUseConsumableChargeHint": "Bei Nutzung dieses {type} wird eine Ladung verbraucht und {value} verbleiben.",
+    "DND5E.AbilityUseConsumableDestroyHint": "Bei Nutzung {type} wird die letzte Anwendung verbraucht und der Gegenstand zerstört.",
+    "DND5E.AbilityUseConsumableDestroyResourceHint": "Bei Nutzung vom {type} wird die letzte Ladung von {name} verbraucht und zerstört.",
+    "DND5E.AbilityUseConsumableLabel": "{max} per {per}",
+    "DND5E.AbilityUseConsumableQuantityHint": "Bei Nutzung dieses {type} wird eine Anwendung verbraucht und {quantity} verbleiben",
+    "DND5E.AbilityUseConsume": "Verfügbare Ladungen verbrauchen?",
+    "DND5E.AbilityUseConsumeAction": "Ladung verbrauchen",
+    "DND5E.AbilityUseHint": "Bearbeite Verwendung von {type} {name}.",
+    "DND5E.AbilityUseNormalHint": "{type} hat {value} von {max} Anwendungen pro {per} verbleibend.",
+    "DND5E.AbilityUseRechargeHint": "{type} ist verbraucht und muss aufgeladen werden!",
+    "DND5E.AbilityUseUnavailableHint": "Es sind keine Anwendungen mehr vorhanden!",
+    "DND5E.AbilityUseUse": "Fertigkeit benutzen",
+    "DND5E.AbilityWis": "Weisheit",
+    "DND5E.AbilityWisAbbr": "Wei",
+    "DND5E.Action": "Aktion",
+    "DND5E.ActionAbbr": "A",
+    "DND5E.ActionAbil": "Attributswurf",
+    "DND5E.ActionEnch": "Verzaubern",
+    "DND5E.ActionHeal": "Heilung",
+    "DND5E.ActionMSAK": "Nahkampf-Zauberangriff",
+    "DND5E.ActionMWAK": "Nahkampf-Waffenangriff",
+    "DND5E.ActionOther": "Andere",
+    "DND5E.ActionPl": "Aktionen",
+    "DND5E.ActionRSAK": "Fernkampf-Zauberangriff",
+    "DND5E.ActionRWAK": "Fernkampf-Waffenangriff",
+    "DND5E.ActionSave": "Rettungswurf",
+    "DND5E.ActionSumm": "Beschwören",
+    "DND5E.ActionUtil": "Utility",
+    "DND5E.ActionWarningNoItem": "Das angefragte Objekt {item} existiert nicht mehr bei Charakter {name}",
+    "DND5E.ActionWarningNoToken": "Um diese Option zu verwenden, brauchst du Kontrolle über mindestens eine Figur.",
+    "DND5E.ActiveEffectOverrideWarning": "Dieser Wert wird von einem Aktive Effekt beeinflusst und kann nicht bearbeitet werden. Zum Bearbeiten Effekt deaktivieren.",
+    "DND5E.ActorWarningInvalidItem": "{itemType} Items können nicht zu {actorType} hinzugefügt werden.",
+    "DND5E.ActorWarningSingleton": "Nur ein {itemType} kann zum {actorType} hinzugefügt werden.",
+    "DND5E.Add": "Neu",
+    "DND5E.AddEmbeddedItemPromptHint": "Diese Items zum Charakterbogen hinzufügen?",
+    "DND5E.AdditionalControls": "Zusätzliche Steuerelemente",
+    "DND5E.AdditionalSettings": "Zusätzliche Einstellungen",
+    "DND5E.Advanced": "Erweitert",
+    "DND5E.AdvancementChoices": "Auswahl",
+    "DND5E.AdvancementClassRestriction": "Klassenbeschränkung",
+    "DND5E.AdvancementClassRestrictionNone": "Alle Klassen",
+    "DND5E.AdvancementClassRestrictionPrimary": "Nur ursprüngliche Klasse",
+    "DND5E.AdvancementClassRestrictionSecondary": "Nur Klassenkombinationen",
+    "DND5E.AdvancementConfigurationActionDisable": "Konfiguration deaktivieren",
+    "DND5E.AdvancementConfigurationActionEnable": "Konfiguration aktivieren",
+    "DND5E.AdvancementConfigurationModeDisabled": "Konfiguration deaktiviert",
+    "DND5E.AdvancementConfigurationModeEnabled": "Konfiguration aktiviert",
+    "DND5E.AdvancementConfigureAllowDrops": "Reinziehen erlauben",
+    "DND5E.AdvancementConfigureAllowDropsHint": "Dürfen Spieler selbst Items in diesen Fortschritt ziehen?",
+    "DND5E.AdvancementConfigureDropAreaHint": "Hier Items hinziehen, um sie der möglichen Auswahl für Spieler hinzuzufügen.",
+    "DND5E.AdvancementConfigureTitle": "{item} Fortschritt bearbeiten",
+    "DND5E.AdvancementConfiguredComplete": "Vollständig konfiguriert",
+    "DND5E.AdvancementConfiguredIncomplete": "Nicht konfiguriert",
+    "DND5E.AdvancementControlCreate": "Erstelle Fortschritt",
+    "DND5E.AdvancementControlDelete": "Lösche Fortschritt",
+    "DND5E.AdvancementControlDuplicate": "Dupliziere Fortschritt",
+    "DND5E.AdvancementControlEdit": "Bearbeite Fortschritt",
+    "DND5E.AdvancementCustomIcon": "Eigenes Icon",
+    "DND5E.AdvancementCustomTitle": "Eigener Titel",
+    "DND5E.AdvancementDeleteConfirmationLabel": "Änderung durch Fortschritt entfernen",
+    "DND5E.AdvancementDeleteConfirmationMessage": "Dieses Item zu entfernen, entfernt auch alle dafür getroffenen Fortschrittsentscheidungen. Diese werden vom Charakter entfernt, wenn die Checkbox unten aktiviert ist.",
+    "DND5E.AdvancementDeleteConfirmationTitle": "Entfernen bestätigen",
+    "DND5E.AdvancementFlowDropAreaHint": "Item hierhin ziehen, um es auszuwählen.",
+    "DND5E.AdvancementHint": "Hinweis",
+    "DND5E.AdvancementHitPointsAverage": "Durchschnitt nehmen",
+    "DND5E.AdvancementHitPointsEmptyError": "Trefferpunkte müssen gewählt oder der Durchschnitt genommen werden.",
+    "DND5E.AdvancementHitPointsHint": "Verfolge die Trefferpunkte des Spielers für jede Stufe in der Klasse.",
+    "DND5E.AdvancementHitPointsInvalidError": "Trefferpunkte müssen eine ganze Zahl sein.",
+    "DND5E.AdvancementHitPointsMaxAtFirstLevel": "Maximum auf Stufe 1: <strong>{max}</strong>",
+    "DND5E.AdvancementHitPointsRollButton": "Würfle {die}",
+    "DND5E.AdvancementHitPointsRollMessage": "Würfle {class} Trefferpunkte",
+    "DND5E.AdvancementHitPointsTitle": "Trefferpunkte",
+    "DND5E.AdvancementItemChoiceChoices": "Auswahlmöglichkeiten",
+    "DND5E.AdvancementItemChoiceChoose": "wähle {count}",
+    "DND5E.AdvancementItemChoiceChosen": "Gewählt: {current} von {max}",
+    "DND5E.AdvancementItemChoiceFeatureLevelWarning": "Muss mindestens Stufe {Stufe} sein, um dieses Merkmal nutzen zu können.",
+    "DND5E.AdvancementItemChoiceHint": "Lässt den Spieler aus mehreren Items (wie Ausrüstung, Merkmalen oder Zaubern) auf einer oder mehreren Stufen wählen.",
+    "DND5E.AdvancementItemChoiceLevelsHint": "Wie viele Items dürfen je Stufe gewählt werden?",
+    "DND5E.AdvancementItemChoiceNoOriginalError": "Die zuvor gewählte Auswahl kann nicht mehr ersetzt werden.",
+    "DND5E.AdvancementItemChoicePreviouslyChosenWarning": "Dises Item wurde bereits auf einer vorherigen Stufe gewählt.",
+    "DND5E.AdvancementItemChoiceReplacement": "Ersetzen möglich",
+    "DND5E.AdvancementItemChoiceReplacementNone": "Nichts ersetzen",
+    "DND5E.AdvancementItemChoiceReplacementTitle": "Ersetzen",
+    "DND5E.AdvancementItemChoiceSpellLevelAvailable": "Jeder verfügbare Grad",
+    "DND5E.AdvancementItemChoiceSpellLevelAvailableWarning": "Nur {level} oder niedrigere Zauber können für diesen Fortschritt gewählt werden.",
+    "DND5E.AdvancementItemChoiceSpellLevelHint": "Erlaubt nur die Wahl von Zaubern diesen Grades.",
+    "DND5E.AdvancementItemChoiceSpellLevelSpecificWarning": "Nur {level} Zauber können für diesen Fortschritt gewählt werden.",
+    "DND5E.AdvancementItemChoiceTitle": "Items wählen",
+    "DND5E.AdvancementItemChoiceType": "Itemtyp",
+    "DND5E.AdvancementItemChoiceTypeAny": "Alles",
+    "DND5E.AdvancementItemChoiceTypeHint": "Schränkt ein, welche Arten von Items gewählt werden können.",
+    "DND5E.AdvancementItemChoiceTypeWarning": "Nur {type}-Items können für diese Wahl gewählt werden.",
+    "DND5E.AdvancementItemGrantContainerWarning": "Der Inhalt von Behältern wird nicht zu den Behältern hinzugefügt.",
+    "DND5E.AdvancementItemGrantDropHint": "Items hierhin ziehen, um sie zu der Liste der Items hinzuzufügen, die durch diesen Fortschritt gewährt werden.",
+    "DND5E.AdvancementItemGrantDuplicateWarning": "Dieses Items existiert bereits in diesem Fortschritt.",
+    "DND5E.AdvancementItemGrantHint": "Gewährt dem Charakter Items (wie Ausrüstung, Merkmale oder Zauber), wenn er eine bestimmte Stufe erreicht.",
+    "DND5E.AdvancementItemGrantOptional": "Optional",
+    "DND5E.AdvancementItemGrantOptionalHint": "Wenn optional, erhalten Spieler die Option, jedes der folgenden Items abzulehnen, ansonsten werden alle gewährt.",
+    "DND5E.AdvancementItemGrantRecursiveWarning": "Kann kein Item gewähren, dass selbst ein Fortschritt ist.",
+    "DND5E.AdvancementItemGrantTitle": "Items gewähren",
+    "DND5E.AdvancementItemTypeInvalidWarning": "Items vom Typ {type} können nicht mit diesem Fortschrittstyp hinzugefügt werden.",
+    "DND5E.AdvancementLevelAnyHeader": "Jede Stufe",
+    "DND5E.AdvancementLevelDownConfirmationMessage": "Diese Klasse herabzustufen wird auch alle Fortschrittsentscheidungen rückgängig machen. Diese werden vom Charaktere entfernt, wenn die Checkbox unten aktiviert ist.",
+    "DND5E.AdvancementLevelDownConfirmationTitle": "Herabstufen bestätigen",
+    "DND5E.AdvancementLevelHeader": "Stufe {level}",
+    "DND5E.AdvancementLevelNoneHeader": "Keine Stufe",
+    "DND5E.AdvancementManagerCloseButtonContinue": "Weiter",
+    "DND5E.AdvancementManagerCloseButtonStop": "Fortschritt stoppen",
+    "DND5E.AdvancementManagerCloseMessage": "<p>Wenn der Fortschrittsprozess angebrochen wird, werden bisher getroffene Entscheidungen verworfen und keine Änderungen am Akteur vorgenommen.</p>",
+    "DND5E.AdvancementManagerCloseTitle": "Fortschritt stoppen",
+    "DND5E.AdvancementManagerComplete": "Fertig",
+    "DND5E.AdvancementManagerLevelIncreasedTitle": "Charakter-Stufenaufstieg",
+    "DND5E.AdvancementManagerLevelNewClassTitle": "Klasse hinzufügen",
+    "DND5E.AdvancementManagerModifyChoicesTitle": "Auswahl ändern",
+    "DND5E.AdvancementManagerNextStep": "Nächste",
+    "DND5E.AdvancementManagerPreviousStep": "Vorherige",
+    "DND5E.AdvancementManagerRestart": "Reset",
+    "DND5E.AdvancementManagerRestartConfirm": "Alle bisherigen Entscheidungen zurücksetzen?",
+    "DND5E.AdvancementManagerRestartConfirmTitle": "Fortschrittsentscheidungen neu starten",
+    "DND5E.AdvancementManagerSteps": "Schritt {current} von {total}",
+    "DND5E.AdvancementManagerTitle": "Fortschritt",
+    "DND5E.AdvancementMigrationConfirm": "Migrationen anwenden",
+    "DND5E.AdvancementMigrationHint": "Wählen, welche der folgenden Fortschritte {name} hinzugefügt werden.",
+    "DND5E.AdvancementMigrationTitle": "Fortschritte migrieren",
+    "DND5E.AdvancementModifyChoices": "Auswahl ändern",
+    "DND5E.AdvancementSaveButton": "Fortschritt speichern",
+    "DND5E.AdvancementScaleValueHint": "Ein einzelner Wert, der sich mit dem Stufenfortschritt der Klasse verändert und in Würfelformeln zur Verfügung steht (z.B. wie der Kampfkünstewürfel des Mönchs).",
+    "DND5E.AdvancementScaleValueIdentifierDiceHint": "Dieser skalierende Wert kann für die aktuelle Stufe wie folgt in einer Formel eingesetzt werden:<br><copyable-text>@scale.{class}.{identifier}</copyable-text> - gesamte Formel (<code>4d6</code>)<br><copyable-text>@scale.{class}.{identifier}.die</copyable-text> - Würfel (<code>d6</code>)<br><copyable-text>@scale.{class}.{identifier}.number</copyable-text> - Anzahl der Würfel (<code>4</code>)<br><copyable-text>@scale.{class}.{identifier}.faces</copyable-text> - Anzahl der Seiten (<code>6</code>)",
+    "DND5E.AdvancementScaleValueIdentifierHint": "Dieser skalierende Wert kann für die aktuelle Stufe mit <strong>@scale.{class}.{identifier}</strong> in einer Formel eingesetzt werden.",
+    "DND5E.AdvancementScaleValueTitle": "Skalierender Wert",
+    "DND5E.AdvancementScaleValueTypeCR": "Herausforderungsgrad",
+    "DND5E.AdvancementScaleValueTypeDice": "Würfel",
+    "DND5E.AdvancementScaleValueTypeDistance": "Distanz",
+    "DND5E.AdvancementScaleValueTypeHintCR": "Diesen Typ für Herausforderungsgrade nutzen, z.B. für Merkmale wie Tiergestalt.",
+    "DND5E.AdvancementScaleValueTypeHintDice": "Diesen Typ für Würfelwerte nutzen, wie z.B. den Bonusschaden durch hinterhältige Angriffe oder Bardische Inspiration.",
+    "DND5E.AdvancementScaleValueTypeHintDistance": "Diesen Wert für numerische Werte nutzen, die eine Distanz repräsentieren, z.B. Ungerüstete Bewegung oder den Radius der Aura des Schutzes.",
+    "DND5E.AdvancementScaleValueTypeHintNumber": "Diesen Typ für rein numerische Werte nutzen, wie z.B. die Anzahl Nutzungen am Tag oder den Schadensbonus vom Kampfrausch.",
+    "DND5E.AdvancementScaleValueTypeHintString": "Diesen Typ nutzen, wenn der Typ des Werts unbekannt oder unwichtig ist.",
+    "DND5E.AdvancementScaleValueTypeLabel": "Typ",
+    "DND5E.AdvancementScaleValueTypeNumber": "Numerisch",
+    "DND5E.AdvancementScaleValueTypeString": "Beliebig",
+    "DND5E.AdvancementSelectionCreateButton": "Fortschritt erstellen",
+    "DND5E.AdvancementSelectionTitle": "Fortschrittstyp wählen",
+    "DND5E.AdvancementSizeFlowHintSingle": "Deine Größe ist {size}.",
+    "DND5E.AdvancementSizeHint": "Legt die Größe eines Charakters fest.",
+    "DND5E.AdvancementSizeTitle": "Größe",
+    "DND5E.AdvancementSizeflowHintMultiple": "Wähle deine Größe zwischen {sizes}.",
+    "DND5E.AdvancementTitle": "Fortschritt",
+    "DND5E.AdvancementTraitActionAddChoice": "Auswahl hinzufügen",
+    "DND5E.AdvancementTraitActionRemoveChoice": "Auswahl entfernen",
+    "DND5E.AdvancementTraitAllowReplacements": "Ersatz erlauben",
+    "DND5E.AdvancementTraitAllowReplacementsHint": "Wenn ein Merkmal bereits auf dem Akteur vorhanden ist, kann der Spieler ein beliebiges anderes Merkmal als Ersatz wählen.",
+    "DND5E.AdvancementTraitChoices": "Auswahl",
+    "DND5E.AdvancementTraitChoicesHint": "Die folgenden Merkmale werden dem Spieler zur Auswahl gestellt.",
+    "DND5E.AdvancementTraitChoicesRemaining": "Wähle {count} weitere {type}",
+    "DND5E.AdvancementTraitCount": "Anzahl",
+    "DND5E.AdvancementTraitGrants": "Garantiert",
+    "DND5E.AdvancementTraitGrantsHint": "Die folgenden Merkmale werden dem Charakter verliehen, sofern dieser nicht bereits über dieses Merkmal verfügt.",
+    "DND5E.AdvancementTraitHint": "Gewährt einem Charakter bestimmte Merkmale oder die Möglichkeit Merkmale auszuwählen (z.B. Übungen, Fertigkeiten, Sprachen).",
+    "DND5E.AdvancementTraitMode": "Modus",
+    "DND5E.AdvancementTraitModeDefaultHint": "Gewährt ein Merkmal oder eine Übung",
+    "DND5E.AdvancementTraitModeDefaultLabel": "Standard",
+    "DND5E.AdvancementTraitModeExpertiseHint": "Gewährt Expertise in einer Fertigkeit in der du bereits geübt bist.",
+    "DND5E.AdvancementTraitModeExpertiseLabel": "Expertise",
+    "DND5E.AdvancementTraitModeForceHint": "Gewährt Expertise in einer Fertigkeit unabhängig von der Übung.",
+    "DND5E.AdvancementTraitModeForceLabel": "Erzwungene Expertise",
+    "DND5E.AdvancementTraitModeMasteryHint": "Erhalte Meisterschaft mit einer Waffe mit der du bereits geübt bist.",
+    "DND5E.AdvancementTraitModeMasteryLabel": "Meisterschaft",
+    "DND5E.AdvancementTraitModeUpgradeHint": "Gewährt Übung in einer Fertigkeit, es sei denn, du hast diese bereits, gewährt dann Expertise.",
+    "DND5E.AdvancementTraitModeUpgradeLabel": "Upgrade",
+    "DND5E.AdvancementTraitTitle": "Merkmale",
+    "DND5E.AdvancementTraitType": "Merkmal Typ",
+    "DND5E.Advantage": "Vorteil",
+    "DND5E.AdvantageMode": "Vorteilmodus",
+    "DND5E.Age": "Alter",
+    "DND5E.Alignment": "Gesinnung",
+    "DND5E.AlignmentCE": "Chaotisch Böse",
+    "DND5E.AlignmentCG": "Chaotisch Gut",
+    "DND5E.AlignmentCN": "Chaotisch Neutral",
+    "DND5E.AlignmentLE": "Rechtschaffen Böse",
+    "DND5E.AlignmentLG": "Rechtschaffen Gut",
+    "DND5E.AlignmentLN": "Rechtschaffen Neutral",
+    "DND5E.AlignmentNE": "Neutral Böse",
+    "DND5E.AlignmentNG": "Neutral Gut",
+    "DND5E.AlignmentTN": "Neutral",
+    "DND5E.Amount": "Anzahl",
+    "DND5E.Appearance": "Erscheinung",
+    "DND5E.Apply": "Anwenden",
+    "DND5E.AreaOfEffect": "Wirkungsbereich",
+    "DND5E.Armor": "Rüstung",
+    "DND5E.ArmorClass": "Rüstungsklasse",
+    "DND5E.ArmorClassCalculation": "Berechnung",
+    "DND5E.ArmorClassCustom": "Eigene Formel",
+    "DND5E.ArmorClassDraconic": "Drakonische Widerstandskraft",
+    "DND5E.ArmorClassEquipment": "Angelegte Rüstung",
+    "DND5E.ArmorClassFlat": "Pauschal",
+    "DND5E.ArmorClassFormula": "Formel",
+    "DND5E.ArmorClassMage": "Magierrüstung",
+    "DND5E.ArmorClassMotionless": "Bewegunglose Rüstungsklasse",
+    "DND5E.ArmorClassNatural": "Natürliche Rüstung",
+    "DND5E.ArmorClassUnarmored": "Ungerüstet",
+    "DND5E.ArmorClassUnarmoredBarbarian": "Ungerüstete Verteidigung (Barbar)",
+    "DND5E.ArmorClassUnarmoredBard": "Ungerüstete Verteidigung (Barde)",
+    "DND5E.ArmorClassUnarmoredMonk": "Ungerüstete Verteidigung (Mönch)",
+    "DND5E.ArmorConfig": "Rüstung bearbeiten",
+    "DND5E.ArmorConfigHint": "Feld oben ausfüllen, um die automatisch berechnete Rüstungsklasse zu überschreiben.",
+    "DND5E.ArmorHeavyProficiency": "Schwer",
+    "DND5E.ArmorLightProficiency": "Leicht",
+    "DND5E.ArmorMediumProficiency": "Mittel",
+    "DND5E.ArmorValue": "Rüstungswert",
+    "DND5E.Attack": "Angriff",
+    "DND5E.AttackPl": "Angriffe",
+    "DND5E.AttackRoll": "Angriffswurf",
+    "DND5E.AttrConcentration": {
+        "Limit": "Limit"
+    },
+    "DND5E.Attributes": "Attribute",
+    "DND5E.Attuned": "Eingestimmt",
+    "DND5E.Attunement": "Einstimmung",
+    "DND5E.AttunementAttuned": "Eingestimmt",
+    "DND5E.AttunementMax": "Maximal Eingestimmte Gegenstände",
+    "DND5E.AttunementNone": "Einstimmung nicht nötig",
+    "DND5E.AttunementOptional": "Einstimmung optional",
+    "DND5E.AttunementOverride": "Einstimmung überschreiben",
+    "DND5E.AttunementRequired": "Einstimmung nötig",
+    "DND5E.Automatic": "Automatisch",
+    "DND5E.AutomaticValue": "Automatisch ({value})",
+    "DND5E.Award": {
+        "Action": "Belohnung",
+        "Distribution": {
+            "Each": "Jeder",
+            "Split": "Aufteilen"
+        },
+        "Message": "{name} has been awarded {award}.",
+        "NoDestinations": "Kein Ziel verfügbar",
+        "NoPrimaryParty": "Keine primäre Gruppe festgelegt, zeigt stattdessen die den Spielern zugewiesenen Charaktere.",
+        "NotGMError": "Der /award Befehl ist nur für SL verfügbar.",
+        "Title": "Belohnung verteilen",
+        "UnrecognizedWarning": "Kann {commands} nicht parsen. Der Befehl /award sollte mit XP und Währungen verwendet werden wie '/award 10gp 50xp'"
+    },
+    "DND5E.Background": "Hintergrund",
+    "DND5E.BackgroundAdd": "Hintergrund hinzufügen",
+    "DND5E.BackgroundName": "Hintergrundname",
+    "DND5E.Biography": "Biographie",
+    "DND5E.BiographyPublic": "Öffentliche Biographie",
+    "DND5E.BiopgrahyPublicEdit": "Bearbeite Öffentliche Biographie",
+    "DND5E.Bonds": "Bindungen",
+    "DND5E.Bonus": "Bonus",
+    "DND5E.BonusAbility": "Globaler Attributsbonus",
+    "DND5E.BonusAbilityCheck": "Genereller Bonus auf Attributswürfe",
+    "DND5E.BonusAbilitySave": "Genereller Bonus auf Rettungswürfe",
+    "DND5E.BonusAbilitySaveTitle": "Generelle Rettungswürfe",
+    "DND5E.BonusAbilitySkill": "Genereller Bonus auf Fertigkeiten",
+    "DND5E.BonusAction": "Bonusaktion",
+    "DND5E.BonusActionAbbr": "BA",
+    "DND5E.BonusAttack": "Angriffsbonus",
+    "DND5E.BonusDamage": "Schadensbonus",
+    "DND5E.BonusMSAttack": "Nahkampf-Zauberangriffs Bonus",
+    "DND5E.BonusMSDamage": "Nahkampf-Zauberangriff Schadens Bonus",
+    "DND5E.BonusMWAttack": "Nahkampf-Waffenangriffs Bonus",
+    "DND5E.BonusMWDamage": "Nahkampf-Waffenangriff Schadens Bonus",
+    "DND5E.BonusRSAttack": "Fernkampf-Zauberangriffs Bonus",
+    "DND5E.BonusRSDamage": "Fernkampf-Zauberangriff Schadens Bonus",
+    "DND5E.BonusRWAttack": "Fernkampf-Waffenangriffs Bonus",
+    "DND5E.BonusRWDamage": "Fernkampf-Waffenangriff Schadens Bonus",
+    "DND5E.BonusSaveForm": "Aktualisierter Bonus",
+    "DND5E.BonusSpell": "Globale Zauberboni",
+    "DND5E.BonusSpellDC": "Genereller Zauber SG Bonus",
+    "DND5E.BonusTitle": "Bearbeite Spielercharakter-Boni",
+    "DND5E.Bonuses": "Generelle Boni",
+    "DND5E.BonusesHint": "Definiere generelle Boni als Formeln, die zu bestimmten Würfen hinzugefügt werden. Zum Beispiel: 1d4 + 2",
+    "DND5E.BonusesInstructions": "Bearbeite Charakter-Boni, die dem entsprechenden Würfelwurf hinzugefügt werden",
+    "DND5E.CAST": "{'Title': 'Zauber wirken', 'FIELDS': {'spell': {'label': 'Zauberwirken Details', 'challenge': {'attack': {'label': 'Angriffsbonus', 'hint': 'Fester Trefferbonus, der anstelle des normalen Angriffsbonus des Zaubers verwendet wird.'}, 'save': {'label': 'Rettungswurf-SG', 'hint': 'Fester SG, der anstelle des normalen Rettungswurf-SG des Zaubers verwendet wird.'}, 'override': {'label': 'Werte überschreiben', 'hint': 'Überschreibe beim Wirken den normalen Angriffsbonus und SG des Zaubers.'}}, 'level': {'label': 'Zaubergrad', 'hint': 'Basisstufe des Zaubers, falls sie sich von der Stufe des Zaubers unterscheidet.'}, 'properties': {'label': 'Ignorierte Eigenschaften', 'hint': 'Zauberkomponenten und Eigenschaften, die beim Zaubern ignoriert werden.'}, 'spellbook': {'label': 'Im Zauberbuch anzeigen', 'hint': 'Den Zauber im Zauber Reiter des Charakterbogens anzeigen.'}, 'uuid': {'label': 'Zauber der gewirkt wird'}}}, 'SECTIONS': {'Spell': 'Zauber', 'Spellbook': 'Zusätzliche Zauber'}, 'Action': {'RemoveSpell': 'Zauber entfernen'}, 'Enchantment': {'Name': 'Änderungen am Zauber'}}",
+    "DND5E.CHECK": {
+        "FIELDS": {
+            "check": {
+                "ability": {
+                    "hint": "Attribut das für die Probe genutzt wird.",
+                    "label": "Proben Attribut"
+                },
+                "associated": {
+                    "hint": "Führe die Attributsproben anhand Übung und Boni mit diesen Fertigkeiten und Werkzeugen durch.",
+                    "label": "Assoziierte Fertigkeiten oder Werkzeuge"
+                },
+                "dc": {
+                    "calculation": {
+                        "hint": "Methode oder Attribut, das zur Berechnung des Schwierigkeitsgrades verwendet wird.",
+                        "label": "SG Berechnung"
+                    },
+                    "formula": {
+                        "hint": "Eigene Formel oder fester Wert zur Definition des Proben-SG.",
+                        "label": "SG Formel"
+                    },
+                    "label": "Schwierigkeitsgrad"
+                },
+                "label": "Proben-Details"
+            }
+        },
+        "ThisTool": "Dieses Werkzeug",
+        "Title": "Probe"
+    },
+    "DND5E.CLASS": {
+        "FIELDS": {
+            "hitDice": {
+                "label": "Trefferwürfel"
+            },
+            "hitDiceUsed": {
+                "label": "Verbrauchte Trefferwürfel"
+            },
+            "levels": {
+                "label": "Klassenstufe"
+            },
+            "primaryAbility": {
+                "all": {
+                    "hint": "Benötige alle primären Attribute auf dem Minimum, um mehrere Klassen zu spielen.",
+                    "label": "Benötigt Alle"
+                },
+                "value": {
+                    "hint": "Attribute, die von dieser Klasse am häufigsten verwendet werden. Dient zur Bestimmung der Voraussetzung für Klassenkombinationen.",
+                    "label": "Primärattribut"
+                }
+            }
+        },
+        "Multiclass": {
+            "Title": "Klassenkombinationen"
+        }
+    },
+    "DND5E.CONSUMABLE": {
+        "Category": {
+            "Poison": "Gift"
+        },
+        "FIELDS": {
+            "damage": {
+                "label": "Munitionsschaden",
+                "replace": {
+                    "hint": "Ersetze den Basis-Waffenschaden mit diesem Schaden anstatt ihn zu erhöhen.",
+                    "label": "Ersetze Waffenschaden"
+                }
+            },
+            "magicalBonus": {
+                "label": "Magischer Bonus"
+            },
+            "properties": {
+                "label": "Verbrauchsgut Eigenschaften"
+            },
+            "uses": {
+                "autoDestroy": {
+                    "hint": "Reduziere die Menge des Items um 1, wenn alle Limitierten Nutzungen aufgebraucht sind.",
+                    "label": "Zerstöre wenn Leer"
+                }
+            }
+        },
+        "Type": {
+            "Ammunition": {
+                "Arrow": "Pfeil",
+                "Bolt": "Bolzen",
+                "BulletFirearm": "Kugel, Feuerwaffe",
+                "BulletSling": "Kugel, Schleuder",
+                "Label": "Munition",
+                "Needle": "Nadel"
+            },
+            "Food": {
+                "Label": "Nahrung"
+            },
+            "Poison": {
+                "Contact": "Kontakt",
+                "Ingested": "Einnahme",
+                "Inhaled": "Eingeatmet",
+                "Injury": "Verletzung",
+                "Label": "Gift"
+            },
+            "Potion": {
+                "Label": "Trank"
+            },
+            "Rod": {
+                "Label": "Rute"
+            },
+            "Scroll": {
+                "Label": "Schriftrolle"
+            },
+            "Trinket": {
+                "Label": "Schmuckstück"
+            },
+            "Wand": {
+                "Label": "Zauberstab"
             }
         }
-    }
-},
-   "DND5E.Value": "Wert",
-   "DND5E.Vehicle": "Fahrzeug",
-   "DND5E.VehicleActionMax": "Max. Aktionen",
-   "DND5E.VehicleActionStations": "Aktionsstationen",
-   "DND5E.VehicleActionThresholds": "Aktionsschwellenwerte",
-   "DND5E.VehicleActionThresholdsFull": "Volle Besatzung",
-   "DND5E.VehicleActionThresholdsMid": "Teilweise Besatzung",
-   "DND5E.VehicleActionThresholdsMin": "Minimale Besatzung",
-   "DND5E.VehicleActions": "Aktionen",
-   "DND5E.VehicleActionsHint": "Aktionen mit voller Besatzung",
-   "DND5E.VehicleCargo": "Fracht",
-   "DND5E.VehicleCargoCapacity": "Frachtkapazität",
-   "DND5E.VehicleCargoCrew": "Fracht/Besatzung",
-   "DND5E.VehicleCreatureCapacity": "Besatzungskapazität",
-   "DND5E.VehicleCrew": "Besatzung",
-   "DND5E.VehicleCrewAction": "Besatzungsaktion",
-   "DND5E.VehicleCrewPassengers": "Besatzung & Passagiere",
-   "DND5E.VehicleCrewed": "Bemannt",
-   "DND5E.VehicleEquipment": "Fahrzeugausstattung",
-   "DND5E.VehicleMishap": "Panne",
-   "DND5E.VehicleMishapThreshold": "Unfall Grenzwert",
-   "DND5E.VehiclePassengerName": "Passagiername oder Typ",
-   "DND5E.VehiclePassengerQuantity": "Passagierzahl",
-   "DND5E.VehiclePassengers": "Passagiere",
-   "DND5E.VehicleType": "Fahrzeugtyp",
-   "DND5E.VehicleTypeAir": "Luftfahrzeug",
-   "DND5E.VehicleTypeLand": "Landfahrzeug",
-   "DND5E.VehicleTypeSpace": "Weltraumfahrzeug",
-   "DND5E.VehicleTypeWater": "Wasserfahrzeug",
-   "DND5E.VehicleUncrewed": "Unbemannt",
-   "DND5E.Versatile": "Vielseitig",
-   "DND5E.VersatileDamage": "Vielseitig: Schaden",
-   "DND5E.VsDC": "gg. SG.",
-   "DND5E.Vulnerabilities": "Verwundbarkeiten",
-   "DND5E.WarnBadACFormula": "Die genutzte RK-Formel konnte nicht evaluiert werden.",
-   "DND5E.WarnCantAddMultipleAdvancements": "Es ist momentan nicht möglich, gleichzeitig mehrere Items mit Fortschritten einem Akteur hinzuzufügen. Bitte Items einzeln hinzufügen.",
-   "DND5E.WarnMultipleArmor": "Mehr als eine Rüstung ausgerüstet, RK-Berechnung ist möglicherweise inkorrekt.",
-   "DND5E.WarnMultipleShields": "Mehr als ein Schild ausgerüstet, RK-Berechnung ist möglicherweise inkorrekt.",
-   "DND5E.WEAPON": {
-    "FIELDS": {
-         "ammunition": {
-             "type": {
-                 "label": "Munitionstyp"
-             }
-         },
-         "damage": {
-             "hint": "Würfel für intrinsische Schäden der Waffe. Modifikatoren für Attribute und zusätzliche Schadensbestandteile werden beim Angriff automatisch bereitgestellt."
-         },
-         "mastery": {
-             "label": "Meisterschaft",
-             "hint": "Spezielles Waffenattribut für Charaktere freigeschaltet, die die Waffenmeisterschaft oder ein verwandtes Merkmal besitzen."
-         }
-     },
-     "Mastery": {
-         "Label": "Waffenmeisterschaft",
-         "Flavor": "Meisterschaft",
-         "Cleave": "Spalten",
-         "Graze": "Streifen",
-         "Nick": "Schwingen",
-         "Push": "Stoßen",
-         "Sap": "Betäuben",
-         "Slow": "Verlangsamen",
-         "Topple": "Stürzen",
-         "Vex": "Wüten"
-     }
- },
-   "DND5E.WeaponCategory": "{category} Waffe",
-   "DND5E.WeaponImprov": "Improvisiert",
-   "DND5E.WeaponMartialM": "Kriegswaffe Nah.",
-   "DND5E.WeaponMartialProficiency": "Übung Kriegswaffen",
-   "DND5E.WeaponMartialR": "Kriegswaffe Fern.",
-   "DND5E.WeaponNatural": "Natürlich",
-"DND5E.WeaponOtherProficiency": "Andere",
-   "DND5E.WeaponSiege": "Belagerungswaffe",
-   "DND5E.WeaponSimpleM": "Einfache Waffe Nah.",
-   "DND5E.WeaponSimpleProficiency": "Übung Einfache Waffen",
-   "DND5E.WeaponSimpleR": "Einfache Waffe Fern.",
-   "DND5E.Weight": "Gewicht",
-   "DND5E.WeightUnit": {
-       "Label": "Gewichtseinheiten",
-       "Kilograms": {
-           "Label": "Kilogramm",
-           "Abbreviation": "kg"
-       },
-       "Megagrams": {
-           "Label": "Tonnen",
-           "Abbreviation": "t"
-       },
-       "Pounds": {
-           "Label": "Pfund",
-           "Abbreviation": "lb"
-       },
-       "Tons": {
-           "Label": "Tonnen",
-           "Abbreviation": "tn"
-       }
-   },
-   "DND5E.WhisperedTo": "Flüstern zu",
-   "DND5E.Wiki": "Wiki",
-   "DND5E.available": "verfügbar",
-   "DND5E.description": "Ein umfassendes Spielsystem zum Spielen der Dungeons & Dragons 5. Edition in Foundry VTT.",
-   "DND5E.of": "von",
-   "DND5E.per": "per",
-   "DND5E.spell": "Zauber",
-   "EDITOR.DND5E.Inline": {
-       "ApplyStatus": "Status auf ausgewählte Token anwenden",
-       "AwardEach": "{award} jeden",
-       "CheckShort": "{check}",
-       "CheckLong": "{check} prüfung",
-       "DamageShort": "{formula} {type}",
-       "DamageLong": "{average} ({formula}) {type}",
-       "DC": "SG {dc} {check}",
-       "DCPassiveShort": "SG {dc} passiver {check}",
-       "DCPassiveLong": "passiver {check} Wert von {dc} oder höher",
-       "NoActorWarning": "Es konnte kein ausgewählter oder zugewiesener Akteur gefunden werden, um den Wurf auszuführen",
-       "RequestRoll": "Wurf anfragen",
-       "RollRequest": "Anfragen eines Wurfes",
-       "SaveShort": "{save}",
-       "SaveLong": "{save} Rettungswurf",
-       "SpecificCheck": "{ability} ({type})",
-       "Warning": {
-           "NoActor": "Es konnte kein ausgewählter oder zugewiesener Akteur gefunden werden um diesen Wurf auszuführen",
-           "NoItemOnActor": "{actor} hat kein Item mit dem Namen {item}.",
-           "NoActivityOnItem": "{item} von {actor} hat keine Aktivität mit dem Namen {activity}."
-       }
-   },
-   "DND5E.title": "Dungeons & Dragons 5. Edition",
-   "dnd5e-DE.ProficiencyAbbrev": "ÜB",
-   "EFFECT.DND5E": {
-       "StatusBleeding": "Bluten",
-       "StatusBurrowing": "Eingraben",
-       "StatusConcentrating": "Konzentration",
-       "StatusCursed": "Verflucht",
-       "StatusDead": "Tod",
-       "StatusDodging": "Ausweichen",
-       "StatusEncumbered": "Belastet",
-       "StatusEthereal": "Ätherisch",
-       "StatusExceedingCarryingCapacity": "Überschreitung der Traglastt",
-       "StatusFlying": "Fliegen",
-       "StatusHeavilyEncumbered": "Stark belastet",
-       "StatusHiding": "Verstecken",
-       "StatusHovering": "Schweben",
-       "StatusMarked": "Markiert",
-       "StatusSilenced": "Stumm",
-       "StatusSleeping": "Schlafen",
-       "StatusStable": "Stabil",
-       "StatusSurprised": "Überrascht",
-       "StatusTransformed": "Verwandelt",
-       "StatusBloodied": "Blutig",
-       "StatusBurning": "Brennend",
-       "StatusDehydration": "Dehydrierung",
-       "StatusFalling": "Fallend",
-       "StatusHalfCover": "Halbe Deckung",
-       "StatusMalnutrition": "Unterernährung",
-       "StatusSuffocation": "Ersticken",
-       "StatusThreeQuartersCover": "Dreivierteldeckung",
-       "StatusTotalCover": "Vollständige Deckung"
-   },
-   "TYPES.JournalEntryPage.class": "Klassenübersicht",
-   "TYPES.JournalEntryPage.map": "Karten Standort",
-   "TYPES.JournalEntryPage.rule": "Regel",
-   "TYPES.JournalEntryPage.spells": "Zauberliste",
-   "TYPES.JournalEntryPage.subclass": "Unterklassenübersicht",
-   "MACRO.5eMissingTargetWarn": "Dein kontrollierter Akteur '{actor}' hat kein(en) {type} mit Namen '{name}'.",
-   "MACRO.5eMultipleTargetsWarn": "Dein kontrollierter Akteur '{actor}' hat mehr als ein(en) {type} mit Namen '{name}'. Der erste Treffer wird genutzt.",
-   "MACRO.5eNoActorSelected": "Kein gewählter oder zugewiesener Akteur konnte als Ziel für Makro gefunden werden.",
-   "MACRO.5eUnownedWarn": "Du kannst nur Makrobuttons für Items erstellen, die dir gehören",
-   "MIGRATION.5eBegin": "Migriere DnD5E System zu Version {version}. Bitte Geduld haben und das Spiel nicht schließen oder beenden.",
-   "MIGRATION.5eComplete": "DnD5E System-Migration zu Version {version} abgeschlossen!",
-   "MIGRATION.5eVersionTooOldWarning": "Die DnD5e-Systemdaten stammen von einer zu alten Foundry-Version und können nicht verlässlich migriert werden. Ein Versuch wird unternommen, aber Fehler können auftreten.",
-   "SETTINGS.5eAllowPolymorphingL": "Erlaube den Spielern, ihre eigenen Charaktere zu verwandeln.",
-   "SETTINGS.5eAllowPolymorphingN": "Verwandlung zulassen",
-   "SETTINGS.5eAutoCollapseCardL": "Objektkartenbeschreibungen im Chat-Protokoll automatisch zusammenklappen",
-   "SETTINGS.5eAutoCollapseCardN": "Objektkarten im Chat zusammenklappen",
-   "SETTINGS.5eAutoSpellTemplateL": "Wenn ein Zauberspruch gewirkt wird, beginnt standardmäßig der Prozess zur Erstellung der entsprechenden Messschablone, falls vorhanden (erfordert die Spielerrolle TRUSTED) oder eine höhere Rolle",
-   "SETTINGS.5eAutoSpellTemplateN": "Messschablone immer platzieren",
-   "SETTINGS.5eChallengeVisibility": {
-       "All": "Zeige alle",
-       "Hint": "Lege fest, welche Wurf-SGs für die Spieler sichtbar sind und ob Erfolge/Fehlschäge hervorgehoben werden.",
-       "Name": "Schwieriegkeitsgrad Sichtbarkeit",
-       "None": "Verstecke alle",
-       "Player": "Nur von anderen Spielern zeigen"
-   },
-   "SETTINGS.5eAttackRollVisibility": {
-    "Name": "Angriffsergebnis Sichtbarkeit",
-    "Hint": "Kontrolliere die Sichtbarkeit der Ergebnisse von Angriffswürfen in Chat-Karten für Spieler.",
-    "All": "Zeige Ergebnisse und RK vom Ziel",
-    "HideAC": "Zeige nur Ergebnisse",
-    "None": "Verstecke alle"
-},
-   "SETTINGS.5eCriticalMaxDiceL": "Macht kritische Treffer tödlicher, indem die Werte der Schadenswürfel maximiert werden.",
-   "SETTINGS.5eCriticalMaxDiceN": "Kritischer Schaden Würfel Maximieren",
-   "SETTINGS.5eCriticalModifiersL": "Macht kritischer Treffer tödlicher, indem auch Boni zusätzlich zu den Würfelergebnissen multipliziert werden.",
-   "SETTINGS.5eCriticalModifiersN": "Kritischer Schaden Boni Multiplizieren",
-   "SETTINGS.5eCurWtL": "Mitgeführte Währung beeinflusst die Tragebelastung nach den Regeln des SHB S. 143.",
-   "SETTINGS.5eCurWtN": "Währung hat Gewicht",
-   "SETTINGS.5eDiagDMG": "Spielleiterhandbuch (5/10/5)",
-   "SETTINGS.5eDiagEuclidean": "Euklidisch (7,07 ft. Diagonale)",
-   "SETTINGS.5eDiagL": "Bearbeite, welche Diagonalbewegungsregel für Spiele innerhalb dieses Systems verwendet werden soll.",
-   "SETTINGS.5eDiagN": "Diagonale Bewegungs Regeln",
-   "SETTINGS.5eDiagPHB": "Spielerhandbuch (5/5/5)",
-   "SETTINGS.5eEncumbrance": {
-       "Hint": "Ermöglicht die automatische Verfolgung der Belastung und die Anwendung von Statuseffekten für Charaktere, die zu viel tragen.",
-       "Name": "Verfolgung von Belastung",
-       "None": "keine",
-       "Normal": "Normal (maximale Traglast)",
-       "Variant": "Variante (belastet & stark belastet)"
-   },
-   "SETTINGS.5eFeatsL": "Erlaubt Spielern beim Klassenaufstieg, Talente anstelle einer Attributswerterhöhung zu wählen.",
-   "SETTINGS.5eFeatsN": "Talente erlauben",
-   "SETTINGS.5eHonorL": "Aktiviert die Nutzung des optionalen Ehrenwerts. Erfordert, dass die Welt neu geladen wird.",
-   "SETTINGS.5eHonorN": "Ehre",
-   "SETTINGS.5eInitTBL": "Zähle den Attributswert (GE) zur INI hinzu um Gleichstand zu vermeiden.",
-   "SETTINGS.5eInitTBN": "INI GE Mod",
-   "SETTINGS.5eMetricL": "Ersetzt alle Instanzen von Pfund (lb) mit Kilogramm (kg) und aktualisiert die Traglastberechnung um metrische Einheiten.",
-   "SETTINGS.5eMetricN": "Nutze metrische Gewichtseinheiten",
-   "SETTINGS.5eNoConcentrationN": "Konzentrationsverfolgung deaktivieren",
-   "SETTINGS.5eNoConcentrationL": "Deaktivieren Sie die automatische Verfolgung der Konzentration durch das System.",
-   "SETTINGS.5eNoAdvancementsL": "Bei Stufenaufstieg und Charaktererstellung keine Auswahl abfragen.",
-   "SETTINGS.5eNoAdvancementsN": "Stufenaufstieg nicht automatisieren",
-   "SETTINGS.5eProfBonus": "PHB: Bonus (+2, +3, +4, +5, +6)",
-   "SETTINGS.5eProfDice": "DMG: Würfel (1d4, 1d6, 1d8, 1d10, 1d12)",
-   "SETTINGS.5eProfL": "Konfiguration von Übungsbonus: fester Wert oder Würfelwurf. Neuladen der Welt ist erforderlich, damit eine Änderung wirksam wird.",
-   "SETTINGS.5eProfN": "Übungsvariante",
-   "SETTINGS.5eReset": "Zurücksetzen",
-   "SETTINGS.5eRestEpic": "Episches Heldentum (LR: 1 Std., KR: 1 Min.)",
-   "SETTINGS.5eRestGritty": "Rauer Realismus (LR: 7 Tage, KR: 8 Std.)",
-   "SETTINGS.5eRestL": "Bearbeite, welche Rastregel für Spiele innerhalb dieses Systems verwendet werden soll.",
-   "SETTINGS.5eRestN": "Rast Variante",
-   "SETTINGS.5eRestPHB": "Spielerhandbuch (LR: 8 Std., KR: 1 Std.)",
-   "SETTINGS.5eSanityL": "Aktiviert die Nutzung des optionalen Werts für Geistige Gesundheit. Erfordert, dass die Welt neu geladen wird.",
-   "SETTINGS.5eSanityN": "Geistige Gesundheit",
-   "SETTINGS.5eUndoChanges": "Änderungen zurücksetzen",
-   "JOURNALENTRYPAGE.DND5E": {
-       "Class": {
-           "FIELDS": {
-               "description": {
-                   "additionalEquipment": {
-                       "label": "Zusätzliche Ausrüstung Beschreibung",
-                       "hint": "Zusätzlicher beschreibender Text, der unter dem Startausrüstungsabschnitt angezeigt wird."
-                   },
-                   "additionalHitPoints": {
-                       "label": "Zusätzliche Trefferpunkte Beschreibung",
-                       "hint": "Zusätzlicher beschreibender Text, der unter dem automatisch generierten Trefferpunkte Abschnitt angezeigt wird."
-                   },
-                   "additionalTraits": {
-                       "label": "Zusätzliche Übungen Beschreibung",
-                       "hint": "Zusätzlicher beschreibender Text, der unter der Liste der von dieser Klasse gewährten Übungen angezeigt wird."
-                   },
-                   "subclass": {
-                       "label": "Unterklassen-Einleitung",
-                       "hint": "Einleitung, die vor den Unterklassen dieser Klasse angezeigt wird."
-                   },
-                   "value": {
-                       "label": "Einleitung",
-                       "hint": "Grundsätzliche Beschreibung der Klasse. Wird zuerst angezeigt."
-                   }
-               },
-               "item": {
-                   "label": "Gewählte Klasse"
-               },
-               "style": {
-                   "label": "Stil",
-                   "hint": "Erzwinge die Verwendung der Modernen oder Legacy-Formatierung für den Seitenstil, anstatt des durch die Klasse festgelegten."
-               },
-               "subclassHeader": {
-                   "label": "Unterklassenabschnitt"
-               },
-               "subclassItems": {
-                   "label": "Unterklassen"
-               }
-           },
-           "EquipmentHeader": "Ausrüstung",
-           "EquipmentDescription": "Du beginnst mit der folgenden Ausrüstung, zusätzlich zu der, die du durch deinen Hintergrund erhältst:",
-           "Features": {
-               "DescriptionLegacy": "Als {name} erhältst du die folgenden Klassenmerkmale, die in der {name}-Tabelle zusammengefasst werden.",
-               "DescriptionModern": "Als ein {name}, erhältst du die folgenden Klassenmerkmale wenn du die spezifische {name} Stufe erreichst. Die Merkmale sind in der {name} Merkmale Tabelle gelistet.",
-               "Header": "Klassenmerkmale",
-               "Name": "Stufe {level}: {name}"
-           },
-           "HitPoints": {
-               "Header": "Trefferpunkte",
-               "HitDiceLegacy": "<strong>Trefferwürfel:</strong> {dice} pro Stufe als {class}",
-               "HitDiceModern": "{dice} pro {class} Stufe",
-               "Level1": "<strong>Trefferpunkte auf Stufe 1:</strong> {max} + dein Konstitutionsmodifikator",
-               "LevelX": "<strong>Trefferpunkte auf höheren Stufen:</strong> {dice} (oder {average}) + dein Konstitutionsmodifikator pro Stufe als {class} über die 1. Stufe hinaus"
-           },
-           "ItemHint": "Klasse hierhin ziehen",
-           "NoValidClass": "Keine gültige Klasse gewählt, Bearbeiten nutzen um eine Klasse hinzuzufügen.",
-           "OptionalFeaturesCaption": "Optionale Klassenmerkmale",
-           "OptionalFeaturesDescription": "Der folgende Abschnitt enthält optionale {class}-Klassenmerkmale. Diese werden nicht automatisch zugewiesen und können einzeln, alle oder nach Wahl der Spielleitung gewählt werden.",
-           "SpellSlotLevel": "Platzgrad",
-           "SpellSlots": "Zauberplätze",
-           "SpellSlotsPerSpellLevel": "—Zauberplätze pro Grad—",          
-           "Style": {
-               "Inferred": "Aus Quelle abgeleitet",
-               "Legacy": "Legacy",
-               "Modern": "Modern"
-           },
-           "SubclassHint": "Unterklassen hierhin ziehen",
-           "TableCaption": "{class}",
-           "TableOptionalCaption": "Optionale {class}-Klassenmerkmale",
-           "Traits": {
-               "Caption": "{class} Kernmerkmale",
-               "Header": "Übung"
-           }
-       },
-       "EditDescription": "Bearbeiten",
-       "TableTOC": "Tabelle: {caption}",
-       "SpellList": {
-           "DropHint": "Zauber oder Ordner mit Zaubern hierhin ziehen um die Liste zu ergänzen",
-           "Grouping": {
-               "Label": "Gruppierungsmodus",
-               "Hint": "Legt fest, wie die Zauber standardmäßig in der Zauberliste gruppiert werden sollen.",
-               "Alphabetical": "Nach Anfangsbuchstaben",
-               "Level": "Nach Zaubergrad",
-               "None": "Keine Gruppierung",
-               "School": "Nach Zauberschule"
-           },
-           "IdentifierHint": "Die ID sollte mit der im zugehörigen Dokument definierten ID übereinstimmen, falls zutreffend. Bei der Erstellung einer Zauberliste für die Klasse \"Magier\" sollte die ID beispielsweise \"Magier\" lauten.",
-           "Type": {
-               "Label": "Zauberlisten-Typ",
-               "Other": "Unkategorisiert"
-           },
-           "UnlinkedSpells": {
-               "Label": "Unverlinkte Zauber",
-               "Add": "Unverlinkte Zauber hinzufügen",
-               "Configuration": "Zauberkonfiguration",
-               "Edit": "Unverlinkte Zauber bearbeiten"
-           }
-       },
-       "Subclass": {     
-           "FIELDS": {
-               "description": {
-                   "value": {
-                       "label": "Einleitung",
-                       "hint": "Grundsätzliche Beschreibung der Unterklasse. Wird zuerst angezeigt."
-                   }
-               },
-               "item": {
-                   "label": "Gewählte Unterklasse"
-               },
-               "style": {
-                   "label": "Stil",
-                   "hint": "Force the page style to use modern or legacy formatting, rather than what is specified by the subclass."
-               }
-           },
-           "ItemHint": "Unterklasse hierhin ziehen",
-           "NoValidSubclass": "Keine gültige Unterklasse gewählt, Bearbeiten nutzen um eine Unterlasse hinzuzufügen."
-       }
-   },
-   "KEYBINDINGS.DND5E.SkipDialogNormal": "Überspringe Dialog",
-   "KEYBINDINGS.DND5E.SkipDialogAdvantage": "Überspringe Dialog (Wurf mit Vorteil/Kritisch)",
-   "KEYBINDINGS.DND5E.SkipDialogDisadvantage": "Überspringe Dialog (Wurf mit Nachteil)",
-   "SETTINGS.5eGridAlignedSquareTemplatesL": "Wenn quadratische Schablonen durch das Wirken eines Zaubers oder die Verwendung eines Gegenstands erstellt werden, sind sie an die Ausrichtung des Rasters gebunden und können nicht gedreht werden.",
-   "SETTINGS.5eGridAlignedSquareTemplatesN": "Am Raster ausgerichtete quadratische Schablonen",
-   "SETTINGS.5eTokenRings": {
-       "Name": "Dynamische Token-Ringe deaktivieren",
-       "Hint": "Die Deaktivierung der Token-Ring-Animationen kann die Leistung verbessern."
-   },
-   "SETTINGS.DND5E": {
-       "ALLOWSUMMONING": {
-           "Name": "Beschwörungen erlauben",
-           "Hint": "Erlaubt Spielern, Beschwörungsfähigkeiten zu nutzen, um Akteure zu beschwören. Damit dies funktioniert, müssen die Spieler auch die Berechtigung \"Neue Figuren erstellen\" haben."
-       },
-       "BLOODIED": {
-           "Name": "Blutig Status",
-           "Hint": "Konfiguriere, ob der Blutig Status automatisch verfolgt wird und dessen Sichtbarkeit.",
-           "All": "Anzeigen für Verbündete und Feinde",
-           "Player": "Nur für Verbündete Anzeigen",
-           "None": "Nicht anzeigen"
-       },
-       "COLLAPSETRAYS": {
-           "Name": "Fächer im Chat zusammenklappen",
-           "Hint": "Automatisches Einklappen von Schadens-, Treffer- und Effektfächern, die in Chat-Karten erscheinen.",
-           "Always": "Alle einklappen",
-           "Older": "Ältere Fächer zusammenklappen",
-           "Never": "Alle ausklappen"
-       },
-       "DEFAULTSKILLS": {
-           "Name": "Standard Fertigkeit",
-           "Hint": "Die Fertigkeiten, die unabhängig vom Grad der Übung, Standardmäßig auf den NPC-Bögen erscheinen"
-       },
-       "LEVELING": {
-           "Name": "Stufenaufstieg Modus",
-           "Hint": "Lege fest, wie Spieler neue Stufen aufsteigen.",
-           "NoXP": "Stufenaufstieg ohne EP",
-           "XP": "Erfahrungspunkte",
-           "XPBoons": "Erfahrungspunkte mit Epischen Gaben"
-       },
-"THEME": {
-    "Name": "Thema",
-    "Hint": "Thema, das standardmäßig auf die Benutzeroberfläche und alle Blätter angewendet wird. Die Automatik wird durch die Einstellungen Ihres Browsers oder Betriebssystems bestimmt."
-},
-       "RULESVERSION": {
-           "Name": "Regel Version",
-           "Hint": "Ändere die Handhabung verschiedener Regeln zwischen den Regelsätzen von 2024 und 2014",
-           "Legacy": "Legacy Regeln (2014)",
-           "Modern": "Moderne Regeln (2024)"
-       }
-   },
-   "SHEETS.DND5E": {
-       "THEME": {
-           "Label": "Thema",
-           "Automatic": "Automatisch",
-           "Dark": "Dunkler Modus",
-           "Light": "Heller Modus"
-       }
-   },
-   "SOURCE.BOOK.SRD": "System Reference Document 5.1",
-   "SIDEBAR.SortModePriority": "Nach Priorität sortieren"
+    },
+    "DND5E.CONSUMPTION": {
+        "Action": {
+            "ConsumeResource": "Ressource verbrauchen",
+            "Create": "Verbrauchsziel erstellen",
+            "Delete": "Verbrauchsziel entfernen",
+            "RefundResource": "Ressource Zurückerstatten"
+        },
+        "FIELDS": {
+            "consumption": {
+                "label": "Verbrauch",
+                "scaling": {
+                    "abbr": "Skalierung",
+                    "allowed": {
+                        "hint": "Kann eine Aktivität, die nicht in einem Zauber enthalten ist, auf höheren Stufen aktiviert werden?",
+                        "label": "Skalierung Erlauben"
+                    },
+                    "label": "Verbrauch Skalieren",
+                    "max": {
+                        "hint": "Maximale Anzahl von Skalierungsebenen für dieses Item, einschließlich der Basisstufe.",
+                        "label": "Maximale Skalierung"
+                    }
+                },
+                "spellSlot": {
+                    "hint": "Soll die Verwendung dieser Aktivität einen Zauberplatz für diesen Zauber verbrauchen?",
+                    "label": "Verbrauche Zauberplatz"
+                },
+                "targets": {
+                    "FIELDS": {
+                        "scaling": {
+                            "formula": {
+                                "hint": "Individuelle Skalierung der Verbrauchsmenge pro Stufe.",
+                                "label": "Skalierungsformel"
+                            },
+                            "label": "Verbrauchsskalierung",
+                            "mode": {
+                                "hint": "Wie der Verbrauch skaliert werden sollte.",
+                                "label": "Skalierungsmodus"
+                            }
+                        },
+                        "target": {
+                            "hint": "Spezifisches Ziel das verbraucht werden soll.",
+                            "label": "Verbrauchsziel"
+                        },
+                        "type": {
+                            "hint": "Art des Verbrauchsziels.",
+                            "label": "Verbrauchstyp"
+                        },
+                        "value": {
+                            "hint": "Gib einen negativen Wert ein, um wiederherzustellen, statt zu verbrauchen.",
+                            "label": "Verbrauchsmenge"
+                        }
+                    },
+                    "hint": "Ziele des möglichen Verbrauchs, wenn diese Aktivität aktiviert wird.",
+                    "label": "Verbrauchsziele"
+                }
+            }
+        },
+        "Scaling": {
+            "Amount": "Anzahl",
+            "Automatic": "Automatisch",
+            "None": "Keine Skalierung",
+            "SlotLevel": "Zauberplatzgrad"
+        },
+        "Target": {
+            "ThisItem": "Dieses Item"
+        },
+        "Type": {
+            "ActivityUses": {
+                "Label": "Aktivität Nutzungen",
+                "PromptDecrease": "Aktivität Nutzung Verbrauchen?",
+                "PromptHintDecrease": "Gib <strong>{cost}</strong> {use} von dieser Aktivität.",
+                "PromptHintIncrease": "Erhalte <strong>{cost}</strong> {use} für diese Aktivität.",
+                "PromptIncrease": "Aktivität Nutzung Wiederherstellen?",
+                "Warning": "Nutzungen von {item} Aktivität {activity}"
+            },
+            "Attribute": {
+                "Label": "Attribut",
+                "PromptDecrease": "Attribut Verbrauchen?",
+                "PromptHintDecrease": "Verringere <code>{attribute}</code> um <strong>{cost}</strong>.",
+                "PromptHintIncrease": "Erhöhe <code>{attribute}</code> um <strong>{cost}</strong>.",
+                "PromptIncrease": "Attribut Wiederherstellen?",
+                "Warning": "{attribute} Anzahl"
+            },
+            "HitDice": {
+                "Label": "Tefferwürfel",
+                "PromptDecrease": "Trefferwürfel Verbrauchen?",
+                "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {denomination} {die}.",
+                "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {denomination} {die}.",
+                "PromptIncrease": "Trefferwürfel Wiederherstellen?",
+                "Warning": "{denomination} Trefferwürfel"
+            },
+            "HitDie": {
+                "one": "Trefferwürfel",
+                "other": "Trefferwürfel"
+            },
+            "ItemUses": {
+                "Label": "Itemnutzungen",
+                "PromptDecrease": "Itemnutzung Verbrauchen?",
+                "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {use} von {item}.",
+                "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {use} von {item}.",
+                "PromptIncrease": "Itemnutzung Wiederherstellen?",
+                "Warning": "Nutzungen von {name}"
+            },
+            "Material": {
+                "Label": "Material",
+                "PromptDecrease": "Material Verbrauchen?",
+                "PromptHintDecrease": "Verringere Anzahl von {item} um <strong>{cost}</strong>.",
+                "PromptHintIncrease": "Erhöhe Anzahl von {item} um <strong>{cost}</strong>.",
+                "PromptIncrease": "Material Wiederherstellen?",
+                "Warning": "Von {name}"
+            },
+            "SpellSlot": {
+                "one": "{level}. Grad",
+                "other": "{level}. Grade"
+            },
+            "SpellSlots": {
+                "Label": "Zauberplätze",
+                "PromptDecrease": "Zauberplatz verbrauchen?",
+                "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {slot}.",
+                "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {slot}.",
+                "PromptIncrease": "Zauberplatz wiederherstellen?",
+                "Warning": "{level}. Grad"
+            },
+            "Use": {
+                "one": "Nutzung",
+                "other": "Nutzungen"
+            }
+        },
+        "Warning": {
+            "MissingAttribute": "Das Attribut {attribute}, das für die Verwendung durch die {activity} Aktivität auf dem {item} konfiguriert wurde, konnte nicht gefunden werden.",
+            "MissingHitDice": "Der Akteur hat keine Klasse mit einem {denomination} Trefferwürfel",
+            "MissingItem": "Das Item, das für den Verbrauch durch die {activity} Aktivität auf {item} konfiguriert wurde, konnte nicht gefunden werden.",
+            "MissingSpellSlot": "Keine {level}. Grad Plätze verfügbar.",
+            "None": "Kein {type} verfügbar zum verbrauchen, {cost} benötigt",
+            "NotEnough": "Nicht genug {type} verfügbar zum verbrauchen, {cost} benötigt und nur {available} verfügbar."
+        }
+    },
+    "DND5E.CRLabel": "HG {cr}",
+    "DND5E.Casting": "Wirken",
+    "DND5E.ChallengeRating": "Herausforderungsgrad",
+    "DND5E.Charged": "Aufladen",
+    "DND5E.Charges": "Ladungen",
+    "DND5E.ChatContextDamage": "Schaden verursachen",
+    "DND5E.ChatContextDoubleDamage": "Verursacht doppelten Schaden",
+    "DND5E.ChatContextHalfDamage": "Verursacht halben Schaden",
+    "DND5E.ChatContextHealing": "Heilung anwenden",
+    "DND5E.ChatContextSelectHit": "Wähle getroffene Ziele",
+    "DND5E.ChatContextSelectMiss": "Wähle verfehlte Ziele",
+    "DND5E.ChatContextTempHP": "Temporäre TP anwenden",
+    "DND5E.ChatFlavor": "Chatnachrichten-Flavortext",
+    "DND5E.CheckBonus": "Probenbonus",
+    "DND5E.ClassAdd": "Klasse hinzufügen",
+    "DND5E.ClassIdentifier": "Klassen-ID",
+    "DND5E.ClassIdentifierHint": "Die Daten dieser Klasse werden unter der ID <strong>@classes.{identifier}</strong> in Formeln verfügbar sein.",
+    "DND5E.ClassLevels": "Klassenstufen",
+    "DND5E.ClassMakeOriginal": "Ursprungsklasse",
+    "DND5E.ClassMakeOriginalHint": "Erste Klasse, die von einem Charakter gewählt wurde. Wird genutzt, um manche Klasseneigenschaften bei Klassenkombinationen zu bestimmen.",
+    "DND5E.ClassName": "Klassenname",
+    "DND5E.ClassOriginal": "Ursprungsklasse",
+    "DND5E.ClassSaves": "Rettungswürfe",
+    "DND5E.CompendiumBrowser": {
+        "Action": {
+            "Open": "Kompendium Browser öffnen"
+        },
+        "Column": {
+            "Icon": "Icon",
+            "Name": "Name",
+            "Results": "Ergebnisse",
+            "Source": "Quelle"
+        },
+        "Filters": {
+            "HasDarkvision": "Hat Dunkelsicht",
+            "HasSpellcasting": "Hat Zauberwirken",
+            "Label": "Filter",
+            "SearchResults": "Ergebnisse Durchsuchen"
+        },
+        "Locked": "Gesperrt",
+        "Selection": {
+            "Label": "Ausgewählt: {summary}",
+            "Select": "Auswählen",
+            "Summary": {
+                "Max": "<span class=\"value\">{value}</span> von bis zu {max}",
+                "Min": "<span class=\"value\">{value}</span> von mindestens {min}",
+                "Range": "<span class=\"value\">{value}</span> von {min} bis {max}",
+                "Single": "<span class=\"value\">{value}</span> von {max}"
+            },
+            "Warning": {
+                "Document": {
+                    "one": "Dokument",
+                    "other": "Dokumente"
+                },
+                "Max": "Muss maximal {max} {document} auswählen, {value} ausgewählt.",
+                "Min": "Muss mindestens {min} {document} auswählen, {value} ausgewählt.",
+                "Range": "Muss zwischen {min} und {max} {document} auswählen, {value} ausgewählt.",
+                "Single": "Muss {max} {document} auswählen, {value} ausgewählt."
+            }
+        },
+        "Sources": {
+            "FilterPackages": "Pakete Filtern",
+            "Hint": "Konfiguriere, welche Kompendienpakete im Kompendium Browser verfügbar sind.",
+            "Label": "Konfiguriere Quellen",
+            "Name": "Compendium Browser Quellen"
+        },
+        "Tabs": {
+            "Feat.other": "Merkmale",
+            "Item.other": "Items",
+            "Monster.other": "Monster"
+        },
+        "Title": "Kompendium Browser",
+        "Types": {
+            "Label": "Typen"
+        }
+    },
+    "DND5E.ComponentMaterial": "Material",
+    "DND5E.ComponentMaterialAbbr": "M",
+    "DND5E.ComponentSomatic": "Gesten",
+    "DND5E.ComponentSomaticAbbr": "G",
+    "DND5E.ComponentVerbal": "Verbal",
+    "DND5E.ComponentVerbalAbbr": "V",
+    "DND5E.Components": "Komponenten",
+    "DND5E.ConBlinded": "Blind",
+    "DND5E.ConCharmed": "Bezaubert",
+    "DND5E.ConDeafened": "Taub",
+    "DND5E.ConDiseased": "Erkrankt",
+    "DND5E.ConExhaustion": "Erschöpft",
+    "DND5E.ConFrightened": "Verängstigt",
+    "DND5E.ConGrappled": "Gepackt",
+    "DND5E.ConImm": "Zustandsimmunitäten",
+    "DND5E.ConIncapacitated": "Kampfunfähig",
+    "DND5E.ConInvisible": "Unsichtbar",
+    "DND5E.ConParalyzed": "Gelähmt",
+    "DND5E.ConPetrified": "Versteinert",
+    "DND5E.ConPoisoned": "Vergiftet",
+    "DND5E.ConProne": "Liegend",
+    "DND5E.ConRestrained": "Festgesetzt",
+    "DND5E.ConStunned": "Betäubt",
+    "DND5E.ConUnconscious": "Bewusstlos",
+    "DND5E.ConcentratingEnd": "Konzentration beenden",
+    "DND5E.ConcentratingEndChoice": "Du konzentrierst dich auf Effekte aus mehr als einer Quelle. Wählen Sie aus, welche Effekte Sie beenden wollen.",
+    "DND5E.ConcentratingItemless": "Konzentration ohne Quelle",
+    "DND5E.ConcentratingLimited": "Du bist nicht in der Lage, dich auf einen zusätzlichen Effekt zu konzentrieren.",
+    "DND5E.ConcentratingMissingItem": "Die Effekte, auf die man sich konzentriert und die ersetzt werden sollen, gibt es nicht.",
+    "DND5E.ConcentratingOn": "Du hältst die Konzentration auf die Effekte von '{Name}' {Typ} aufrecht.",
+    "DND5E.ConcentratingWarnLimit": "Sie können sich nicht auf mehrere Effekte konzentrieren!",
+    "DND5E.ConcentratingWarnLimitOptional": "Du kannst die Konzentration auf einen deiner aufrechterhaltenen Effekte beenden, um diesen Gegenstand zu benutzen.",
+    "DND5E.ConcentratingWarnLimitZero": "Du bist nicht in der Lage, dich auf irgendwelche Effekte zu konzentrieren!",
+    "DND5E.Concentration": "Konzentration",
+    "DND5E.ConcentrationAbbr": "K",
+    "DND5E.ConcentrationBonus": "Konzentrationsbonus",
+    "DND5E.ConcentrationBreak": "Breche Konzentration",
+    "DND5E.ConcentrationBreakWarning": "Das Brechen der Konzentration auf einen Effekt, der bei anderen Kreaturen aktiv ist, erfordert die Anwesenheit eines aktiven SL.",
+    "DND5E.ConcentrationConfigurationHint": "Konfiguriere die Konzentrationsmodifikatoren und -boni, die für diese Kreatur gelten.",
+    "DND5E.ConcentrationDuration": "Konzentration, bis zu {duration}",
+    "DND5E.ConcentrationLimit": "Konzentrationsgrenze",
+    "DND5E.Conditions": "Zustände",
+    "DND5E.Confirm": "Bestätigen",
+    "DND5E.ConsumableLastChargeWarn": "Dies ist die letzte Ladung, und wenn sie verbraucht wird, verringert sich auch die Menge des Items um 1",
+    "DND5E.ConsumableUnitWarn": "verbleibende Ladungen",
+    "DND5E.ConsumableUseWarnEnd": "der aktuellen Ladungen",
+    "DND5E.ConsumableUseWarnStart": "dieses Verbrauchsmaterial hat",
+    "DND5E.ConsumableWithoutCharges": "verfügbare und verwendbare Ladungen",
+    "DND5E.ConsumeAmmunition": "Munition",
+    "DND5E.ConsumeAmount": "Verbrauchsmenge",
+    "DND5E.ConsumeAttribute": "Attribute",
+    "DND5E.ConsumeCharges": "Lad. Gegenst.",
+    "DND5E.ConsumeHint": {
+        "Attribute": "Attribute zum verbrauchen (z.B. currency.gp)",
+        "Item": "UUID des Ziels im Kompendium"
+    },
+    "DND5E.ConsumeHitDice": "Trefferwürfel",
+    "DND5E.ConsumeHitDiceLargest": "Größter verfügbarer",
+    "DND5E.ConsumeHitDiceLargestLong": "Größter verfügbarer Trefferwürfel",
+    "DND5E.ConsumeHitDiceSmallest": "Kleinster verfügbarer",
+    "DND5E.ConsumeHitDiceSmallestLong": "Kleinster verfügbarer Trefferwürfel",
+    "DND5E.ConsumeMaterial": "Material",
+    "DND5E.ConsumeRecharge": "Ladung verbrauchen?",
+    "DND5E.ConsumeResource": "Ressource verbrauchen?",
+    "DND5E.ConsumeScaling": "Ressourcen Skalierung",
+    "DND5E.ConsumeScalingLabel": "Use Resources",
+    "DND5E.ConsumeScalingTooltip": "Wenn diese Option angekreuzt ist, erhöht der Verbrauch zusätzlicher Ressourcen die Stufe, auf der der Zauber gewirkt wird.",
+    "DND5E.ConsumeTarget": "Verbrauchsziel",
+    "DND5E.ConsumeTitle": "Ressourcen-Verbrauch",
+    "DND5E.ConsumeType": "Verbrauchstyp",
+    "DND5E.Consumed": "Verbraucht",
+    "DND5E.Container": "Behälter",
+    "DND5E.ContainerDeleteContents": "Alle Items aus dem Behälter löschen.",
+    "DND5E.ContainerDeleteMessage": "Dieser Behälter wird dauerhaft gelöscht und kann nicht wiederhergestellt werden, und die darin enthaltenen {count} Items werden ausgelagert.",
+    "DND5E.ContainerMaxDepth": "Behälter können nicht mehr als {depth} Ebenen tief verschachtelt werden.",
+    "DND5E.ContainerRecursiveError": "Behälter können sich nicht selbst enthalten.",
+    "DND5E.Contents": "Inhalte",
+    "DND5E.ContextMenuActionAttune": "Einstimmen",
+    "DND5E.ContextMenuActionCharge": "Aufladen",
+    "DND5E.ContextMenuActionDelete": "Löschen",
+    "DND5E.ContextMenuActionDisable": "Deaktivieren",
+    "DND5E.ContextMenuActionDuplicate": "Duplizieren",
+    "DND5E.ContextMenuActionEdit": "Bearbeiten",
+    "DND5E.ContextMenuActionEnable": "Aktivieren",
+    "DND5E.ContextMenuActionEquip": "Ausrüsten",
+    "DND5E.ContextMenuActionExpendCharge": "Entladen",
+    "DND5E.ContextMenuActionPrepare": "Vorbereiten",
+    "DND5E.ContextMenuActionUnattune": "Einstimmung brechen",
+    "DND5E.ContextMenuActionUnequip": "Ablegen",
+    "DND5E.ContextMenuActionUnprepare": "Vorbereitung aufheben",
+    "DND5E.ContextMenuActionView": "Anzeigen",
+    "DND5E.Contiguous": "Angrenzend",
+    "DND5E.Controls": {
+        "Activity": {
+            "FastForwardHint": "<kbd>Shift</kbd> + <left-click> das Item, um diesen Dialog zu überspringen"
+        },
+        "Hint": "Aktivieren Sie verschiedene Hinweise auf der Benutzeroberfläche für bestimmte Maus- und Tastatursteuerungen.",
+        "LeftClick": "Links Klick",
+        "LockHint": "Mittlere Maustaste zum sperren",
+        "MiddleClick": "Mittlere Maustaste",
+        "Name": "Aktiviere Steuerungshinweise"
+    },
+    "DND5E.Copied": "{value} kopiert",
+    "DND5E.Copy": "Text kopieren",
+    "DND5E.Cost": "Kosten",
+    "DND5E.CostGP": "Kosten (GM)",
+    "DND5E.Cover": "Deckung",
+    "DND5E.CoverHalf": "Halbe",
+    "DND5E.CoverThreeQuarters": "Dreiviertel",
+    "DND5E.CoverTotal": "Volle",
+    "DND5E.CreatureAberration": "Aberration",
+    "DND5E.CreatureAberrationPl": "Aberrationen",
+    "DND5E.CreatureBeast": "Tier",
+    "DND5E.CreatureBeastPl": "Tiere",
+    "DND5E.CreatureCelestial": "Himmlisches Wesen",
+    "DND5E.CreatureCelestialPl": "Himmlische Wesen",
+    "DND5E.CreatureConstruct": "Konstrukt",
+    "DND5E.CreatureConstructPl": "Konstrukte",
+    "DND5E.CreatureDragon": "Drache",
+    "DND5E.CreatureDragonPl": "Drachen",
+    "DND5E.CreatureElemental": "Elementar",
+    "DND5E.CreatureElementalPl": "Elementare",
+    "DND5E.CreatureFey": "Feenwesen",
+    "DND5E.CreatureFeyPl": "Feenwesen",
+    "DND5E.CreatureFiend": "Unhold",
+    "DND5E.CreatureFiendPl": "Unholde",
+    "DND5E.CreatureGiant": "Riese",
+    "DND5E.CreatureGiantPl": "Riesen",
+    "DND5E.CreatureHumanoid": "Humanoider",
+    "DND5E.CreatureHumanoidPl": "Humanoide",
+    "DND5E.CreatureMonstrosity": "Monstrosität",
+    "DND5E.CreatureMonstrosityPl": "Monstrositäten",
+    "DND5E.CreatureOoze": "Schlick",
+    "DND5E.CreatureOozePl": "Schlicke",
+    "DND5E.CreaturePlant": "Pflanze",
+    "DND5E.CreaturePlantPl": "Pflanzen",
+    "DND5E.CreatureSwarm": "Schwarm",
+    "DND5E.CreatureSwarmPhrase": "Schwarm von {size} {type}",
+    "DND5E.CreatureSwarmSize": "Schwarmgröße",
+    "DND5E.CreatureType": "Kreaturentyp",
+    "DND5E.CreatureTypeConfig": "Kreaturentyp bearbeiten",
+    "DND5E.CreatureTypeSelectorCustom": "Eigener Typ",
+    "DND5E.CreatureTypeSelectorSubtype": "Subtyp",
+    "DND5E.CreatureTypeTitle": "Kreaturentyp bearbeiten",
+    "DND5E.CreatureUndead": "Untoter",
+    "DND5E.CreatureUndeadPl": "Untote",
+    "DND5E.Crewed": "Bemannt",
+    "DND5E.Critical": "Kritisch",
+    "DND5E.CriticalHit": "Kritischer Treffer",
+    "DND5E.Currency": "Währung",
+    "DND5E.CurrencyAbbrCP": "km",
+    "DND5E.CurrencyAbbrEP": "em",
+    "DND5E.CurrencyAbbrGP": "gm",
+    "DND5E.CurrencyAbbrPP": "pm",
+    "DND5E.CurrencyAbbrSP": "sm",
+    "DND5E.CurrencyCP": "Kupfer",
+    "DND5E.CurrencyEP": "Elektrum",
+    "DND5E.CurrencyGP": "Gold",
+    "DND5E.CurrencyManager": {
+        "Convert": {
+            "Action": "Alle Währungen umrechnen",
+            "Hint": "Rechnet alle mitgeführten Währungen in den höchstmöglichen Nennwert um, um die Menge der vom Charakter mitgeführten Münzen zu reduzieren. Aber Vorsicht: Diese Aktion kann nicht rückgängig gemacht werden.",
+            "Label": "Umrechnen"
+        },
+        "Title": "Währung verwalten",
+        "Transfer": {
+            "Action": "Auswahl übertragen",
+            "All": "Alle",
+            "Half": "Hälfte",
+            "Label": "Übertragen"
+        }
+    },
+    "DND5E.CurrencyPP": "Platin",
+    "DND5E.CurrencySP": "Silber",
+    "DND5E.Current": "Aktuell",
+    "DND5E.DAMAGE": {
+        "FIELDS": {
+            "damage": {
+                "critical": {
+                    "allow": {
+                        "hint": "Sollte die Kreatur kritischen Schaden verursachen können?",
+                        "label": "Erlaube Kritische Treffer"
+                    },
+                    "bonus": {
+                        "hint": "Zusätzlicher Schaden, der dem ersten Schadensbestandteil zugefügt wird, wenn ein kritischer Treffer erzielt wird.",
+                        "label": "Zusätzlicher Kritischer Schaden"
+                    }
+                },
+                "label": "Schaden",
+                "parts": {
+                    "FIELDS": {
+                        "bonus": {
+                            "hint": "Bonus zum Schadenswurf hinzugefügt.",
+                            "label": "Schadensbonus"
+                        },
+                        "custom": {
+                            "enabled": {
+                                "hint": "Verwende eine Eigene Formel anstelle der Standardwürfel.",
+                                "label": "Eigene Formel aktivieren"
+                            },
+                            "formula": {
+                                "hint": "Eigene Schadensformel.",
+                                "label": "Schadensformel"
+                            },
+                            "label": "Eigene Schadensformel"
+                        },
+                        "denomination": {
+                            "hint": "Nennwert des zu werfenden Würfels.",
+                            "label": "Würfel Nennwert"
+                        },
+                        "number": {
+                            "hint": "Zahl des zu werfenden Würfels",
+                            "label": "Würfel Zahl"
+                        },
+                        "scaling": {
+                            "abbr": "Skalierung",
+                            "formula": {
+                                "hint": "Beliebige Skalierungsformel, die für jeden Skalierungsschritt multipliziert und zur ursprünglichen Formel addiert wird.",
+                                "label": "Skalierungsformel"
+                            },
+                            "label": "Schadensskalierung",
+                            "mode": {
+                                "abbr": "Modus",
+                                "hint": "Methode, mit der die Skalierungszunahme berechnet wird.",
+                                "label": "Skalierungsmodus"
+                            },
+                            "number": {
+                                "abbr": "Würfel",
+                                "hint": "Anzahl der Würfel, die für jede Skalierungsstufe erhöht werden. Wird auf den ersten Würfel angewendet, der in der Schadensformel gefunden wird, wenn mehr als einer vorhanden ist.",
+                                "label": "Würfelskalierung"
+                            }
+                        },
+                        "types": {
+                            "hint": "Art des zugefügten Schadens oder mehrere zur Auswahl für den Nutzer.",
+                            "label": "Schadensarten"
+                        }
+                    },
+                    "hint": "Einzelne Schadensbestandteile dem Wurf hinzufügen.",
+                    "label": "Schadensbestandteil"
+                }
+            }
+        },
+        "Part": {
+            "Action": {
+                "Create": "Erstelle Schadensbestandteil",
+                "Delete": "Entferne Schadensbestandteil"
+            }
+        },
+        "Scaling": {
+            "Half": "Jede zweite Stufe",
+            "None": "Keine Skalierung",
+            "Whole": "Jede Stufe"
+        },
+        "Title": "Schaden"
+    },
+    "DND5E.DURATION": {
+        "FIELDS": {
+            "duration": {
+                "concentration": {
+                    "hint": "Die Kreatur muss die Konzentration aktiv halten.",
+                    "label": "Konzentration"
+                },
+                "label": "Dauer",
+                "override": {
+                    "hint": "Verwende diese Dauerwerte anstelle der Dauer des Items, wenn du diese Aktivität verwendest.",
+                    "label": "Dauer überschreiben"
+                },
+                "special": {
+                    "hint": "Beschreibung für jede spezielle Dauer.",
+                    "label": "Spezielle Dauer"
+                },
+                "units": {
+                    "hint": "Einheiten zur Messung der Dauer.",
+                    "label": "Dauer Einheiten"
+                },
+                "value": {
+                    "hint": "Wert der Dauer in den angegebenen Einheiten, falls zutreffend.",
+                    "label": "Dauer Wert"
+                }
+            }
+        }
+    },
+    "DND5E.DamImm": "Schadensimmunitäten",
+    "DND5E.DamMod": "Schadensmodifikation",
+    "DND5E.DamRes": "Schadensresistenzen",
+    "DND5E.DamVuln": "Schadensanfälligkeiten",
+    "DND5E.Damage": "Schaden",
+    "DND5E.DamageAcid": "Säure",
+    "DND5E.DamageAll": "Sämtlicher Schaden",
+    "DND5E.DamageApplication": {
+        "Change": {
+            "Immunity": "{type} Immunität",
+            "Modification": "{type} Modifikation",
+            "Resistance": "{type} Resistenz",
+            "Vulnerability": "{type} Anfälligkeit"
+        },
+        "Downgrading": "{source} runterstufen zu Resistenz",
+        "Ignoring": "Ignoriere {source}"
+    },
+    "DND5E.DamageBludgeoning": "Wucht",
+    "DND5E.DamageCold": "Kälte",
+    "DND5E.DamageFire": "Feuer",
+    "DND5E.DamageForce": "Energie",
+    "DND5E.DamageLightning": "Blitz",
+    "DND5E.DamageModification": {
+        "BypassHint": "Diese Waffeneigenschaften umgehen die Schadensmodifikation für physischen Schaden.",
+        "Hint": "Formeln für die Mengen, die zu dem typisierten Schaden, der auf diesen Akteur angewendet wird, addiert werden. Negative Werte verringern den erlittenen Schaden.",
+        "Label": "Schadensmodifikation"
+    },
+    "DND5E.DamageNecrotic": "Nekrotisch",
+    "DND5E.DamagePhysical": "Nicht-magischer physischer",
+    "DND5E.DamagePhysicalBypass": "Phys. Resistenz-Überwindungen",
+    "DND5E.DamagePhysicalBypassHint": "Diese Waffeneigenschaften ignorieren Schadensresistenzen für physischen Schaden.",
+    "DND5E.DamagePhysicalBypasses": "{damageTypes} von Angriffen, die nicht {bypassTypes} sind",
+    "DND5E.DamagePhysicalBypassesShort": "Umgangen von {type} Quellen",
+    "DND5E.DamagePiercing": "Stich",
+    "DND5E.DamagePoison": "Gift",
+    "DND5E.DamagePsychic": "Psychisch",
+    "DND5E.DamageRadiant": "Gleißend",
+    "DND5E.DamageRoll": "Schadenswurf",
+    "DND5E.DamageSlashing": "Hieb",
+    "DND5E.DamageThreshold": "Schadensgrenzwert",
+    "DND5E.DamageThunder": "Schall",
+    "DND5E.DamageType": "Schadensart",
+    "DND5E.DamageTypes": "Schadensarten",
+    "DND5E.Dawn": "Morgengrauen",
+    "DND5E.Day": "Tag",
+    "DND5E.DeathSave": "RW gg. Tod",
+    "DND5E.DeathSaveCriticalSuccess": "{name} hat den RW gg. Tod kritisch geschafft  und erhält 1 TP!",
+    "DND5E.DeathSaveFailure": "{name} hat 3 RW gg. Tod nicht geschafft und ist tot!",
+    "DND5E.DeathSaveFailureLabel": "Todesrettungswurf Fehlschlag",
+    "DND5E.DeathSaveFailureLabelN.few": "3. Todesrettungswurf Fehlschlag",
+    "DND5E.DeathSaveFailureLabelN.one": "1. Todesrettungswurf Fehlschlag",
+    "DND5E.DeathSaveFailureLabelN.two": "2. Todesrettungswurf Fehlschlage",
+    "DND5E.DeathSaveFailures": "Fehlschläge",
+    "DND5E.DeathSaveHide": "Verstecke Todesrettungswürfe",
+    "DND5E.DeathSaveRoll": "Werfe einen Todesrettungswurf",
+    "DND5E.DeathSaveShow": "Zeige Todesrettungswürfe",
+    "DND5E.DeathSaveSuccess": "{name} hat 3 RW gg. Tod geschafft und ist jetzt stabil!",
+    "DND5E.DeathSaveSuccessLabel": "Todesrettungswurf Erfolg",
+    "DND5E.DeathSaveSuccessLabelN.few": "3. Todesrettungswurf Erfolg",
+    "DND5E.DeathSaveSuccessLabelN.one": "1. Todesrettungswurf Erfolg",
+    "DND5E.DeathSaveSuccessLabelN.two": "2. Todesrettungswurf Erfolg",
+    "DND5E.DeathSaveSuccesses": "Erfolge",
+    "DND5E.DeathSaveUnnecessary": "Du musst keinen Todesrettungswurf ablegen, da du über eine positive Trefferpunktezahl oder bereits 3 Erfolge oder Misserfolge verfügst.",
+    "DND5E.DeathSavingThrow": "RW gg. Tod",
+    "DND5E.Default": "Standard",
+    "DND5E.DefaultAbilityCheck": "Standard Attributswurf",
+    "DND5E.DefaultSpecific": "Standard ({default})",
+    "DND5E.Denomination": "Nennwert",
+    "DND5E.Description": "Beschreibung",
+    "DND5E.DescriptionChat": "Chatbeschreibung",
+    "DND5E.DescriptionEdit": "Bearbeiten {description}",
+    "DND5E.DescriptionSummary": "Beschreibung (Übersicht)",
+    "DND5E.DescriptionUnidentified": "Beschreibung (Unidentifiziert)",
+    "DND5E.Details": "Details",
+    "DND5E.DetailsEdit": "Details bearbeiten",
+    "DND5E.Die": "Würfel",
+    "DND5E.Dimensions": "Abmessungen",
+    "DND5E.Disadvantage": "Nachteil",
+    "DND5E.Disclaimer": "Disclaimer",
+    "DND5E.Discord": "Discord",
+    "DND5E.DistAny": "Jede",
+    "DND5E.DistFt": "Fuß",
+    "DND5E.DistFtAbbr": "ft",
+    "DND5E.DistKm": "Kilometer",
+    "DND5E.DistKmAbbr": "km",
+    "DND5E.DistM": "Meter",
+    "DND5E.DistMAbbr": "m",
+    "DND5E.DistMi": "Meilen",
+    "DND5E.DistMiAbbr": "mi",
+    "DND5E.DistSelf": "Selbst",
+    "DND5E.DistTouch": "Berührung",
+    "DND5E.DocumentUseWarn": "Sie haben keine Erlaubnis, ein Item in diesem Dokument zu verwenden.",
+    "DND5E.DocumentViewWarn": "Sie haben keine Erlaubnis, dieses Dokument einzusehen.",
+    "DND5E.Duration": "Dauer",
+    "DND5E.DurationPermanent": "Permanent",
+    "DND5E.DurationTime": "Zeit",
+    "DND5E.DurationType": "Dauer (Typ)",
+    "DND5E.DurationUnits": "Dauer (Einheiten)",
+    "DND5E.DurationValue": "Dauer (Wert)",
+    "DND5E.Dusk": "Abenddämmerung",
+    "DND5E.EFFECT": {
+        "Action": {
+            "Create": "Erstelle Effekt",
+            "Delete": "Entferne Effekt",
+            "Dissociate": "Trenne Effekt"
+        },
+        "Empty": "Kein verbundener Effekt. Verwende den <i class=\"fas fa-plus\"></i> Knopf, um einen zu erstellen, oder wähle einen vorhandenen Effekt aus dem Dropdown-Menü aus.",
+        "Label": "Verbundene Effekte"
+    },
+    "DND5E.ENCHANT": {
+        "DropArea": "Platziere das Item hier, um es zu verzaubern...",
+        "Enchanted": "{current} &sol; {max} Verzaubert",
+        "Enchantment": {
+            "Action": {
+                "Create": "Erstelle Verzauberung",
+                "Delete": "Entferne Verzauberung"
+            },
+            "Empty": "Keine zugehörigen Verzauberungen. Verwende die Schaltfläche <i class=\"fas fa-plus\"></i> oben, um eine zu erstellen, oder wähle eine vorhandene Verzauberung aus dem Dropdown-Menü aus."
+        },
+        "FIELDS": {
+            "effects": {
+                "FIELDS": {
+                    "level": {
+                        "hint": "Benötigte Stufen, um diesen Zauber zu verwenden.",
+                        "label": "Stufengrenze",
+                        "max": {
+                            "label": "Maximale Stufe"
+                        },
+                        "min": {
+                            "label": "Minimale Stufe"
+                        }
+                    },
+                    "riders": {
+                        "activity": {
+                            "hint": "Diese zusätzlichen Aktivitäten werden dem verzauberten Item hinzugefügt, wenn diese Verzauberung angewendet wird, und entfernt, wenn die Verzauberung entfernt wird.",
+                            "label": "Zusätzliche Aktivitäten"
+                        },
+                        "effect": {
+                            "hint": "Diese zusätzlichen Effekte werden dem verzauberten Item hinzugefügt, wenn diese Verzauberung angewendet wird, und entfernt, wenn die Verzauberung entfernt wird.",
+                            "label": "Zusätzliche Effekte"
+                        },
+                        "item": {
+                            "hint": "Diese zusätzlichen Items werden der Kreatur hinzugefügt, wenn eines ihrer Items verzaubert wird, und werden entfernt, wenn die Verzauberung jemals entfernt wird.",
+                            "label": "Zusätzliche Items"
+                        },
+                        "label": "Angefügt"
+                    }
+                }
+            },
+            "enchant": {
+                "identifier": {
+                    "hint": "ID, die verwendet wird, um zu bestimmen, ob die Charakterstufe oder eine bestimmte Klassenstufe für die Begrenzung der Verzauberungsstufe verwendet werden soll.",
+                    "label": "Klassen-ID"
+                },
+                "label": "Verzauberung Konfiguration"
+            },
+            "restrictions": {
+                "allowMagical": {
+                    "hint": "Erlaube, dass Items, die bereits magisch sind, verzaubert werden können.",
+                    "label": "Erlaube Magisches"
+                },
+                "categories": {
+                    "hint": "Spezifische Item-Kategorien, auf die diese Verzauberung angewendet werden kann.",
+                    "label": "Gültige Kategorien"
+                },
+                "hint": "Einschränkungen hinsichtlich der Art des Items, auf das diese Verzauberung angewendet werden kann.",
+                "label": "Einschränkung",
+                "properties": {
+                    "hint": "Bestimmte Eigenschaften des Items, die vorhanden sein müssen, damit diese Verzauberung angewendet werden kann.",
+                    "label": "Gültige Eigenschaften"
+                },
+                "type": {
+                    "Any": "Jeder verzauberbare Typ",
+                    "hint": "Typ des Items, auf das diese Verzauberung angewendet werden kann.",
+                    "label": "Item-Typ"
+                }
+            }
+        },
+        "SECTIONS": {
+            "Enchanting": "Verzauberung",
+            "Enchantments": "Verzauberungen",
+            "Restrictions": "Einschränkungen"
+        },
+        "Title": "Verzauberung",
+        "Warning": {
+            "ConcentrationEnded": "Diese Verzauberung kann nicht angewendet werden, da die Konzentration beendet ist.",
+            "MissingProperty": "Item muss eine dieser Eigenschaften haben, um verzaubert zu werden: {validProperties}.",
+            "NoMagicalItems": "Items, die bereits magisch sind, können nicht verzaubert werden.",
+            "NoSubtype": "Nur {allowedType}-Items können mit dieser Verzauberung verzaubert werden, aber dieses Item hat keinen Subtyp.",
+            "WrongType": "{incorrectType} Items können nicht mit dieser Verzauberung verzaubert werden, nur {allowedType} Items sind erlaubt."
+        }
+    },
+    "DND5E.ENCHANTMENT": {
+        "Action": {
+            "Apply": "Verzauberung anwenden",
+            "Disable": "Verzauberung deaktivieren",
+            "Edit": "Verzauberung bearbeiten",
+            "Enable": "Verzauberung aktivieren",
+            "Remove": "Verzauberung entfernen"
+        },
+        "Category": {
+            "Active": "Aktive Verzauberungen",
+            "General": "Verzauberungen",
+            "Inactive": "Inaktive Verzauberungen"
+        },
+        "FIELDS": {
+            "enchantment": {
+                "items": {
+                    "max": {
+                        "hint": "Formel für die maximale Anzahl von Verzauberungen dieser Art, die gleichzeitig aktiv sein können.",
+                        "label": "Item Grenze"
+                    },
+                    "period": {
+                        "hint": "Wie oft können Verzauberungen dieser Art auf verschiedene Items übertragen werden?",
+                        "label": "Ersatz Periode"
+                    }
+                },
+                "label": "Verzauberung Konfiguration"
+            }
+        },
+        "Items": {
+            "Entry": "{item} auf <em>{actor}</em>"
+        },
+        "Label": "Verzauberung",
+        "Warning": {
+            "NotOnActor": "Verzauberungen können nur Items hinzugefügt werden, nicht direkt Akteuren.",
+            "Override": "Dieser Wert wird durch eine Verzauberung verändert und kann nicht bearbeitet werden. Deaktiviere die Verzauberung im Reiter Effekte, um sie zu bearbeiten."
+        }
+    },
+    "DND5E.EQUIPMENT": "{'Type': {'Clothing': {'Label': 'Kleidung'}, 'Ring': {'Label': 'Ring'}, 'Rod': {'Label': 'Stab'}, 'Trinket': {'Label': 'Schmuckstück'}, 'Vehicle': {'Label': 'Fahrzeug-Ausrüstung'}, 'Wand': {'Label': 'Zauberstab'}, 'Wondrous': {'Label': 'Wundersamer Gegenstand'}}}",
+    "DND5E.Effect": "Effekt",
+    "DND5E.EffectApplyWarningConcentration": "Das Anwenden eines Effekts, auf den sich ein anderer Charakter konzentriert, erfordert die Erlaubnis des SLs.",
+    "DND5E.EffectApplyWarningOwnership": "Effekte können nicht auf Token angewandt werden, deren Besitzer man nicht ist.",
+    "DND5E.EffectCreate": "Effekt erstellen",
+    "DND5E.EffectDelete": "Effekt löschen",
+    "DND5E.EffectDisable": "Effekt deaktivieren",
+    "DND5E.EffectEdit": "Effekt bearbeiten",
+    "DND5E.EffectEnable": "Effekt aktivieren",
+    "DND5E.EffectInactive": "Inaktive Effekte",
+    "DND5E.EffectNew": "Neuer Effekt",
+    "DND5E.EffectPassive": "Passive Effekte",
+    "DND5E.EffectTemporary": "Temporäre Effekte",
+    "DND5E.EffectToggle": "Effekt umschalten",
+    "DND5E.EffectType": {
+        "Inactive": "Inaktiv",
+        "Passive": "Passiv",
+        "Temporary": "Temporär",
+        "Unavailable": "Nicht verfügbar"
+    },
+    "DND5E.EffectUnavailable": "Nicht verfügbare Effekte",
+    "DND5E.EffectUnavailableInfo": "Quellen-Item muss ausgerüstet oder eingestimmt sein, um diese zu aktivieren",
+    "DND5E.Effects": "Effekte",
+    "DND5E.EffectsApplyTokens": "Auf ausgewählte Token anwenden",
+    "DND5E.EffectsSearch": "Effekte durchsuchen",
+    "DND5E.Encumbrance": "Belastung",
+    "DND5E.Environment": "Umgebung",
+    "DND5E.EquipmentBonus": "Magischer Bonus",
+    "DND5E.EquipmentClothing": "Kleidung",
+    "DND5E.EquipmentHeavy": "Schwere Rüstung",
+    "DND5E.EquipmentLight": "Leichte Rüstung",
+    "DND5E.EquipmentMedium": "Mittelschwere Rüstung",
+    "DND5E.EquipmentNatural": "Natürliche Rüstung",
+    "DND5E.EquipmentShield": "Schild",
+    "DND5E.EquipmentShieldProficiency": "Schilde",
+    "DND5E.EquipmentTrinket": "Schmuckstück",
+    "DND5E.EquipmentVehicle": "Fahrzeugausstattung",
+    "DND5E.Equipped": "Angelegt",
+    "DND5E.Exhaustion": "Erschöpfung",
+    "DND5E.ExhaustionLevel": "Erschöpfung Stufe {n}",
+    "DND5E.ExperiencePoints": "Erfahrungspunkte",
+    "DND5E.ExperiencePointsAbbr": "EP",
+    "DND5E.ExperiencePointsBoons": {
+        "one": "{number} Gabe",
+        "other": "{number} Gaben"
+    },
+    "DND5E.ExperiencePointsCurrent": "Aktuelle EP",
+    "DND5E.ExperiencePointsFormat": "{value} EP",
+    "DND5E.ExperiencePointsLabel": "Fortschritt zur nächsten Stufe",
+    "DND5E.ExperiencePointsMax": "EP für Nächste Stufe",
+    "DND5E.ExperiencePointsMin": "Minimale EP für Diese Stufe",
+    "DND5E.ExperiencePointsValue": "EP-Wert",
+    "DND5E.Expertise": "Expertise",
+    "DND5E.Eyes": "Augen",
+    "DND5E.FLAGS": {
+        "EnhancedDualWielding": {
+            "Hint": "Erlaube Bonusaktionen für zusätzliche Angriffe mit jeder Nahkampfwaffe ohne die Zweihändig Eigenschaft.",
+            "Name": "Verbesserte Beidgändigkeit"
+        }
+    },
+    "DND5E.FORWARD": "{'Title': 'Weiterleiten', 'FIELDS': {'activity': {'label': 'Ausgelöste Aktivität'}}, 'Warning': {'NoActivity': 'Eine verknüpfte Aktivität muss konfiguriert werden, bevor die Weiterleiten-Aktivität verwendet werden kann.'}}",
+    "DND5E.Faith": "Glaube",
+    "DND5E.Favorite": "Favorit",
+    "DND5E.FavoriteDrop": "Favorit hinzufügen",
+    "DND5E.FavoriteRemove": "Favorit entfernen",
+    "DND5E.Favorites": "Favoriten",
+    "DND5E.Feats": "Merkmale",
+    "DND5E.Feature": {
+        "Background": "Hintergrundmerkmal",
+        "Class": {
+            "ArcaneShot": "Arkaner Schuss",
+            "ArtificerInfusion": "Artifizienten-Durchdringung",
+            "ChannelDivinity": "Göttliche Macht fokussieren",
+            "DefensiveTactic": "Defensive Taktik",
+            "EldritchInvocation": "Schauerliche Anrufung",
+            "ElementalDiscipline": "Elementare Disziplin",
+            "FightingStyle": "Kampfstil",
+            "HuntersPrey": "Des Jägers Beute",
+            "Ki": "Ki Fähigkeit",
+            "Label": "Klassenmerkmal",
+            "Maneuver": "Manöver",
+            "Metamagic": "Metamagie Option",
+            "Multiattack": "Mehrfachangriff",
+            "PactBoon": "Segen des Paktes",
+            "PsionicPower": "Psionische Kraft",
+            "Rune": "Rune",
+            "SuperiorHuntersDefense": "Ausserordentliche Verteidigung des Jägers"
+        },
+        "Feat": {
+            "EpicBoon": "Epische Gabe Talent",
+            "FightingStyle": "Kampfstil Talent",
+            "General": "Allgemeines Talent",
+            "Label": "Talent",
+            "Origin": "Ursprung Talent"
+        },
+        "Monster": "Monstermerkmal",
+        "Species": "Speziesmerkmal",
+        "SupernaturalGift": {
+            "Blessing": "Segen",
+            "Charm": "Bezauberung",
+            "EpicBoon": "Epische Gabe",
+            "Label": "Übernatürliches Geschenk"
+        }
+    },
+    "DND5E.FeatureActionRecharge": "Aktion Nachladen",
+    "DND5E.FeatureActive": "Aktive Fähigkeiten",
+    "DND5E.FeatureAdd": "Erschaffe Merkmal",
+    "DND5E.FeatureAttack": "Merkmalsangriff",
+    "DND5E.FeaturePassive": "Passives Merkmal ",
+    "DND5E.FeatureRechargeOn": "Wiederaufladen aktiv",
+    "DND5E.FeatureRechargeResult": "1W6 Ergebnis",
+    "DND5E.FeatureSearch": "Merkmale durchsuchen",
+    "DND5E.FeatureUsage": "Merkmalsverwendung",
+    "DND5E.Features": "Merkmale",
+    "DND5E.FeaturesBackground": "Hintergrundmerkmale",
+    "DND5E.FeaturesClass": "{class} Merkmale",
+    "DND5E.FeaturesOther": "Sonstige Merkmale",
+    "DND5E.FeetAbbr": "ft.",
+    "DND5E.Filter": "Filter",
+    "DND5E.FilterClear": "Filter löschen",
+    "DND5E.FilterGroupAction": "Gruppieren nach Aktion",
+    "DND5E.FilterGroupCategory": "Gruppieren nach Kategorien",
+    "DND5E.FilterGroupOrigin": "Gruppieren nach Herkunft",
+    "DND5E.FilterNoSpells": "Mit diesem Filter wurden keine Zauber gefunden.",
+    "DND5E.FlagsAlert": "Wachsam",
+    "DND5E.FlagsAlertHint": "Verleiht +5 auf Ini.",
+    "DND5E.FlagsAlertHintLegacy": "Gewährt +5 auf Initiative.",
+    "DND5E.FlagsDiamondSoul": "Diamantseele",
+    "DND5E.FlagsDiamondSoulHint": "Erhalte Übung in allen Rettungswürfen.",
+    "DND5E.FlagsElvenAccuracy": "Elfengenauigkeit",
+    "DND5E.FlagsElvenAccuracyHint": "Wenn du bei Würfen für GE, INT, CHA o. WEI im Vorteil bist, darfst du einen Würfel erneut würfeln.",
+    "DND5E.FlagsHalflingLucky": "Halblingsglück",
+    "DND5E.FlagsHalflingLuckyHint": "Bei Proben darfst du deinen Wurf bei einer 1 EINMAL wiederholen.",
+    "DND5E.FlagsInitiativeAdv": "Vorteil bei Initiative",
+    "DND5E.FlagsInitiativeAdvHint": "Durch Merkmale oder magische Gegenstände zur Verfügung gestellt.",
+    "DND5E.FlagsInstructions": "Bearbeite Charaktermerkmale und Talente, die das Verhalten des D&D5e-Systems ändern.",
+    "DND5E.FlagsJOAT": "Alleskönner",
+    "DND5E.FlagsJOATHint": "Halber Übungsbonus auf alle nicht erlernten Fertigkeiten.",
+    "DND5E.FlagsMeleeCriticalDice": "Nahkampf Kritische Schadenswürfel",
+    "DND5E.FlagsMeleeCriticalDiceHint": "Anzahl zusätzlicher Schadenswürfel für kritische Treffer bei Nahkampf-Waffenangriffen.",
+    "DND5E.FlagsObservant": "Aufmerksam",
+    "DND5E.FlagsObservantHint": "Verleiht +5 auf passive Wahrnehmung und Nachforschungen.",
+    "DND5E.FlagsPowerfulBuild": "Mächtiger Körperbau",
+    "DND5E.FlagsPowerfulBuildHint": "Bietet erhöhte Tragfähigkeit.",
+    "DND5E.FlagsReliableTalent": "Verlässliches Talent",
+    "DND5E.FlagsReliableTalentHint": "Schurkenmerkmal Verlässliches Talent.",
+    "DND5E.FlagsRemarkableAthlete": "Bemerkenswerter Athlet.",
+    "DND5E.FlagsRemarkableAthleteHint": "Halber Übungsbonus (aufgerundet) auf körperliche Fertigkeitswürfe und Initiative.",
+    "DND5E.FlagsSave": "Besondere Merkmale aktualisieren",
+    "DND5E.FlagsSpellCritThreshold": "Kritischer Treffer Schwellwert (Zauber)",
+    "DND5E.FlagsSpellCritThresholdHint": "Erweiterter Schwellwert für kritische Treffer bei Angriffen mit Zaubern.",
+    "DND5E.FlagsTavernBrawler": "Kneipenschläger-Talent",
+    "DND5E.FlagsTavernBrawlerHint": "Übung mit improvisierten Waffen.",
+    "DND5E.FlagsTitle": "Besondere Merkmale bearbeiten",
+    "DND5E.FlagsWeaponCritThreshold": "Kritischer Treffer Schwellwert (Waffen)",
+    "DND5E.FlagsWeaponCritThresholdHint": "Erweiterter Schwellwert für kritische Treffer bei Angriffen mit Waffen.",
+    "DND5E.Flat": "Flat",
+    "DND5E.Flaws": "Makel",
+    "DND5E.Focus": {
+        "Arcane": "Arkaner Fokus",
+        "Druidic": "Druidischer Fokus",
+        "Holy": "Heiliges Symbol",
+        "Label": "Zauberfokus"
+    },
+    "DND5E.Formula": "Formel",
+    "DND5E.FormulaCannotContainDiceError": "Formel {name} kann keine Würfelausdrücke enthalten.",
+    "DND5E.FormulaMalformedError": "Problem preparing the {property} formula within {name}.",
+    "DND5E.FormulaMissingReferenceWarn": "The {property} formula within {name} has references to missing data: {references}",
+    "DND5E.Gender": "Geschlecht",
+    "DND5E.GlobalBonus": "Globaler Bonus",
+    "DND5E.GrantedAbilities": "gewährte Fähigkeit",
+    "DND5E.Group": {
+        "Challenge": "Herausforderung",
+        "Member": {
+            "one": "Mitglied",
+            "other": "Mitglieder"
+        },
+        "PlaceMembers": "Platziere Mitglieder",
+        "Primary": {
+            "Remove": "Als primäre Gruppe entfernen",
+            "Set": "Als primäre Gruppe festlegen"
+        },
+        "Type": "Gruppenart",
+        "TypeEncounter": "Begegnung",
+        "TypeGeneric": "Gruppe",
+        "TypeParty": "Gemeinschaft",
+        "Vehicle": {
+            "one": "Fahrzeug",
+            "other": "Fahrzeuge"
+        }
+    },
+    "DND5E.GroupControls": "Steuerung",
+    "DND5E.GroupHP": "Gesamte Trefferpunkte",
+    "DND5E.GroupInventory": "Inventar",
+    "DND5E.GroupSummary": "Eine Gruppe von {members}n",
+    "DND5E.GroupSummaryEmpty": "Leere Gruppe",
+    "DND5E.HEAL": {
+        "FIELDS": {
+            "healing": {
+                "bonus": {
+                    "hint": "Bonus zum Heilungswurf hinzufügen.",
+                    "label": "Heilungsbonus"
+                },
+                "custom": {
+                    "enabled": {
+                        "hint": "Sollte die eigene Formel anstelle der Standardwürfel verwendet werden.",
+                        "label": "Aktiviere Eigene Formel"
+                    },
+                    "formula": {
+                        "hint": "Eigene Heilungsformel",
+                        "label": "Heilungsformel"
+                    },
+                    "label": "Eigene Heilungsformel"
+                },
+                "denomination": {
+                    "hint": "Nennwert des zu werfenden Würfels.",
+                    "label": "Würfel Nennwert"
+                },
+                "label": "Heilung",
+                "number": {
+                    "hint": "Zahl des zu werfenden Würfels",
+                    "label": "Würfel Zahl"
+                },
+                "scaling": {
+                    "formula": {
+                        "hint": "Beliebige Skalierungsformel, die für jeden Skalierungsschritt multipliziert",
+                        "label": "Skalierungsformel"
+                    },
+                    "label": "Heilungsskalierung",
+                    "mode": {
+                        "hint": "Methode, mit der die Skalierungszunahme berechnet wird.",
+                        "label": "Skalierungsmodus"
+                    },
+                    "number": {
+                        "hint": "Anzahl der Würfel, die für jede Skalierungsstufe erhöht werden. Wird auf den ersten Würfel angewendet, der in der Schadensformel gefunden wird, wenn mehr als einer vorhanden ist.",
+                        "label": "Würfelskalierung"
+                    }
+                },
+                "types": {
+                    "hint": "Art der zugefügten Heilung oder mehrere zur Auswahl für den Nutzer.",
+                    "label": "Heilungstyp"
+                }
+            }
+        },
+        "Title": "Heilen"
+    },
+    "DND5E.HITDICE": "{'Action': {'Decrease': 'Verringern', 'Increase': 'Erhöhen'}, 'Config': 'Trefferwürfel anpassen'}",
+    "DND5E.HP": "TP",
+    "DND5E.HPFormula": "Trefferpunkteformel",
+    "DND5E.HPFormulaError": "Die Trefferpunkte-Formel ist ungültig.",
+    "DND5E.HPFormulaRollMessage": "Wurf mit Trefferpunkteformel",
+    "DND5E.Hair": "Haar",
+    "DND5E.HalfProficient": "Halber Übungsbonus",
+    "DND5E.Healing": "Heilung",
+    "DND5E.HealingRoll": "Heilungswurf",
+    "DND5E.HealingTemp": "Heilung (Temporär)",
+    "DND5E.HealthConditions": "Zustandskonditionen",
+    "DND5E.Height": "Größe",
+    "DND5E.HitDice": "Trefferwürfel",
+    "DND5E.HitDiceAutoSpend": {
+        "Hint": "Automatisch Trefferwürfel ausgeben, bis sie aufgebraucht sind oder die Lebenspunkte voll sind.",
+        "Label": "Automatische  Trefferwürfel verwenden"
+    },
+    "DND5E.HitDiceConfig": "Trefferwürfel anpassen",
+    "DND5E.HitDiceConfigHint": "Passt die verbleibenden Tefferwürfelstufen für jede Klasse an.",
+    "DND5E.HitDiceMax": "Maximale Trefferwürfel",
+    "DND5E.HitDiceNPCWarn": "{name} hat keine Trefferwürfel übrig!",
+    "DND5E.HitDiceRemaining": "Verbleibende Trefferwürfel",
+    "DND5E.HitDiceRoll": "Wirf TW",
+    "DND5E.HitDiceWarn": "{name} hat keine {formula} Trefferwürfel übrig!",
+    "DND5E.HitDie": "Trefferwürfel",
+    "DND5E.HitPoints": "Trefferpunkte",
+    "DND5E.HitPointsBonusLevel": "Bonus pro Stufe",
+    "DND5E.HitPointsBonusOverall": "Bonus fest",
+    "DND5E.HitPointsConfig": "Trefferpunkte bearbeiten",
+    "DND5E.HitPointsCurrent": "Aktuelle Trefferpunkte",
+    "DND5E.HitPointsMax": "Maximale Trefferpunkte",
+    "DND5E.HitPointsMin": "Minimale Trefferpunkte",
+    "DND5E.HitPointsOverride": "Maximale Trefferpunkte fest setzen",
+    "DND5E.HitPointsOverrideHint": "Überschreibt automatisch berechnete Trefferpunkte und ignoriert alle TP aus Klassen, Boni und Attributsmodifikatoren.",
+    "DND5E.HitPointsTemp": "Temporäre Trefferpunkte",
+    "DND5E.HitPointsTempMax": "Temporary Maximum Hit Points",
+    "DND5E.HitPointsTempMaxHint": "Temporäre Änderung der maximalen TP.",
+    "DND5E.HitPointsTempMaxShort": "Temp Max TP",
+    "DND5E.HitPointsTempShort": "Temporäre TP",
+    "DND5E.Ideals": "Ideale",
+    "DND5E.Identified": "Identifiziert",
+    "DND5E.Identifier": "ID",
+    "DND5E.IdentifierError": "ID darf nur Buchstaben (a-z), Zahlen (0-9), Bindestriche (-) und Unterstriche (_) enthalten.",
+    "DND5E.Identify": "Identifizieren",
+    "DND5E.Immunities": "Immunitäten",
+    "DND5E.Initiative": "Initiative",
+    "DND5E.InitiativeAbbr": "Init",
+    "DND5E.InitiativeBonus": "Initiativebonus",
+    "DND5E.InitiativeConfig": "Initiative bearbeiten",
+    "DND5E.InitiativeConfigHint": "Initiativmodifikator und Boni für diesen Akteur festlegen.",
+    "DND5E.InitiativeRoll": "Initiativewurf",
+    "DND5E.Inspiration": "Inspiration",
+    "DND5E.Inventory": "Inventar",
+    "DND5E.InventorySearch": "Inventar durchsuchen",
+    "DND5E.Issues": "Issues",
+    "DND5E.Item": {
+        "Category": {
+            "Label": "Ketegorie",
+            "Physical": "Physisch"
+        },
+        "Property": {
+            "Adamantine": "Adamant",
+            "Ammunition": "Geschosse",
+            "Concentration": "Konzentration",
+            "Finesse": "Finesse",
+            "Firearm": "Feuerwaffe",
+            "Focus": "Fokus",
+            "Heavy": "Schwer",
+            "Light": "Leicht",
+            "Loading": "Laden",
+            "Magical": "Magisch",
+            "Material": "Material",
+            "Reach": "Reichweite",
+            "Reload": "Nachladen",
+            "Returning": "Rückkehrend",
+            "Ritual": "Ritual",
+            "Silvered": "Versilbert",
+            "Somatic": "Gestik",
+            "Special": "Spezial",
+            "StealthDisadvantage": "Heimlichkeit Nachteil",
+            "Thrown": "Wurfwaffe",
+            "TwoHanded": "Zweihändig",
+            "Verbal": "Verbal",
+            "Versatile": "Vielseitig",
+            "WeightlessContents": "Gewichtsloser Inhalt"
+        }
+    },
+    "DND5E.ItemActionType": "Aktionstyp",
+    "DND5E.ItemActivation": "Aktivierung",
+    "DND5E.ItemActivationCondition": "Aktivierungsbedingung",
+    "DND5E.ItemActivationCost": "Aktivierungskosten",
+    "DND5E.ItemActivationType": "Aktivierungsart",
+    "DND5E.ItemAmmoProperties": "Munitionseigenschaften",
+    "DND5E.ItemAttackBonus": "Bonus für Angriffwurf",
+    "DND5E.ItemAttackFlat": "Pauschaler Bonus",
+    "DND5E.ItemAttackFlatHint": "Wenn diese Option angekreuzt ist, darfst du dem Angriffswurf keine weiteren Boni hinzufügen, außer denen, die hier angegeben sind.",
+    "DND5E.ItemBackgroundDetails": "Hintergrund-Details",
+    "DND5E.ItemClassDetails": "Klassen-Details",
+    "DND5E.ItemConsumableActivation": "Verbrauchsgut-Aktivierung",
+    "DND5E.ItemConsumableDetails": "Verbrauchsgut-Details",
+    "DND5E.ItemConsumableProperties": "Verbrauchsgut-Eigenschaften",
+    "DND5E.ItemConsumableStatus": "Verbrauchsgut-Status",
+    "DND5E.ItemConsumableSubtype": "{category}-Typ",
+    "DND5E.ItemConsumableType": "Verbrauchsgut-Typ",
+    "DND5E.ItemConsumableUsage": "Verbrauchsgut-Nutzung",
+    "DND5E.ItemContainerCapacity": "Kapazität",
+    "DND5E.ItemContainerCapacityItems": "Gegenstand",
+    "DND5E.ItemContainerCapacityMax": "Max. Kapazität",
+    "DND5E.ItemContainerCapacityType": "Kapazitätstyp",
+    "DND5E.ItemContainerCapacityWeight": "Gewicht",
+    "DND5E.ItemContainerDetails": "Behälter-Details",
+    "DND5E.ItemContainerProperties": "Behälter-Eigenschaften",
+    "DND5E.ItemContainerStatus": "Behälterstatus",
+    "DND5E.ItemCreate": "Gegenstand erstellen",
+    "DND5E.ItemCritExtraDamage": "Zusätz. kritischer Schaden",
+    "DND5E.ItemCritThreshold": "Grenzwert kritischer Treffer",
+    "DND5E.ItemDelete": "Gegenstand löschen",
+    "DND5E.ItemEdit": "Gegenstand bearbeiten",
+    "DND5E.ItemEquipmentAction": "Ausrüstungaktion",
+    "DND5E.ItemEquipmentBase": "Basisausrüstung",
+    "DND5E.ItemEquipmentDetails": "Ausrüstungs-Details",
+    "DND5E.ItemEquipmentDexMod": "Max. Geschicklichkeitsmodifikator",
+    "DND5E.ItemEquipmentDexModAbbr": "Max. Ges",
+    "DND5E.ItemEquipmentProperties": "Ausstattungseigenschaften",
+    "DND5E.ItemEquipmentStatus": "Ausrüstungsstatus",
+    "DND5E.ItemEquipmentStealthDisav": "Erzwingt Heimlichkeitsnachteil",
+    "DND5E.ItemEquipmentType": "Ausrüstungstyp",
+    "DND5E.ItemEquipmentUsage": "Ausrüstungsnutzung",
+    "DND5E.ItemFeatureDetails": "Merkmal-Details",
+    "DND5E.ItemFeatureProperties": "Merkmal Eigenschaften",
+    "DND5E.ItemFeatureSubtype": "{category}-Typ",
+    "DND5E.ItemFeatureType": "Merkmal-Typ",
+    "DND5E.ItemLootDetails": "Beute-Details",
+    "DND5E.ItemLootProperties": "Beuteeigenschaften",
+    "DND5E.ItemLootSubtype": "{category} Typ",
+    "DND5E.ItemLootType": "Beute-Typ",
+    "DND5E.ItemLossRoll": "{name} verliert {count} Aufladungen",
+    "DND5E.ItemName": "Gegenstandsname",
+    "DND5E.ItemNew": "Neu: {type}",
+    "DND5E.ItemRarityArtifact": "artefakt",
+    "DND5E.ItemRarityCommon": "gewöhnlich",
+    "DND5E.ItemRarityLegendary": "legendär",
+    "DND5E.ItemRarityMundane": "alltäglich",
+    "DND5E.ItemRarityRare": "selten",
+    "DND5E.ItemRarityUncommon": "ungewöhnlich",
+    "DND5E.ItemRarityVeryRare": "sehr selten",
+    "DND5E.ItemRechargeCheck": "{name} Aufladeprüfung",
+    "DND5E.ItemRechargeFailure": "Fehlschlag!",
+    "DND5E.ItemRechargeSuccess": "Erfolgreich!",
+    "DND5E.ItemRecoveryFormulaWarning": "{name} kann keine Aufladungen zurückerhalten. Ungültige Formel: '{formula}'.",
+    "DND5E.ItemRecoveryRoll": "{name} erhält {count} Aufladungen zurück",
+    "DND5E.ItemRecoveryRollMax": "{name} erhält alle Aufladungen zurück",
+    "DND5E.ItemRequiredStr": "Benötigte Stärke",
+    "DND5E.ItemSiegeProperties": "Belagerungs-Eigenschaften",
+    "DND5E.ItemSpeciesDetails": "Spezies-Details",
+    "DND5E.ItemSubclassDetails": "Unterklassen-Details",
+    "DND5E.ItemToolBase": "Basiswerkzeug",
+    "DND5E.ItemToolBonus": "Werkzeugbonus",
+    "DND5E.ItemToolDetails": "Werkzeugdetails",
+    "DND5E.ItemToolProficiency": "Handwerkliches Geschick",
+    "DND5E.ItemToolProperties": "Werkzeug Eigenschaften",
+    "DND5E.ItemToolStatus": "Werkzeugstatus",
+    "DND5E.ItemToolType": "Werkzeugtyp",
+    "DND5E.ItemToolUsage": "Werkzeug Nutzung",
+    "DND5E.ItemVehicleProperties": "Fahrzeuge Details",
+    "DND5E.ItemView": "Item anzeigen",
+    "DND5E.ItemWeaponAttack": "Waffenangriff",
+    "DND5E.ItemWeaponBase": "Basiswaffe",
+    "DND5E.ItemWeaponDetails": "Waffendetails",
+    "DND5E.ItemWeaponProperties": "Waffeneigenschaften",
+    "DND5E.ItemWeaponStatus": "Waffenstatus",
+    "DND5E.ItemWeaponType": "Waffentyp",
+    "DND5E.ItemWeaponUsage": "Waffennutzung",
+    "DND5E.JackOfAllTrades": "Alleskönner",
+    "DND5E.LairAct": "Nutzungen Hortaktionen",
+    "DND5E.LairActionInitiative": "Hortaktion Initiativwert",
+    "DND5E.LairActionLabel": "Hort-Aktion",
+    "DND5E.Languages": "Sprachen",
+    "DND5E.LanguagesAarakocra": "Aarakocra",
+    "DND5E.LanguagesAbyssal": "Abyssisch",
+    "DND5E.LanguagesAquan": "Aqual",
+    "DND5E.LanguagesAuran": "Auran",
+    "DND5E.LanguagesCelestial": "Celestisch",
+    "DND5E.LanguagesCommon": "Gemeinsprache",
+    "DND5E.LanguagesCommonSign": "Gemeine Gebärdensprache",
+    "DND5E.LanguagesDeepSpeech": "Tiefensprache",
+    "DND5E.LanguagesDraconic": "Drakonisch",
+    "DND5E.LanguagesDruidic": "Druidisch",
+    "DND5E.LanguagesDwarvish": "Zwergisch",
+    "DND5E.LanguagesElvish": "Elfisch",
+    "DND5E.LanguagesExotic": "Exotische Sprachen",
+    "DND5E.LanguagesExoticLegacy": "Exotische Sprachen",
+    "DND5E.LanguagesGiant": "Riesisch",
+    "DND5E.LanguagesGith": "Gith",
+    "DND5E.LanguagesGnoll": "Gnollisch",
+    "DND5E.LanguagesGnomish": "Gnomisch",
+    "DND5E.LanguagesGoblin": "Goblinisch",
+    "DND5E.LanguagesHalfling": "Halbingisch",
+    "DND5E.LanguagesIgnan": "Ignal",
+    "DND5E.LanguagesInfernal": "Infernalisch",
+    "DND5E.LanguagesOrc": "Orkisch",
+    "DND5E.LanguagesPrimordial": "Urtümlich",
+    "DND5E.LanguagesStandard": "Standard Sprachen",
+    "DND5E.LanguagesSylvan": "Sylvanisch",
+    "DND5E.LanguagesTerran": "Terral",
+    "DND5E.LanguagesThievesCant": "Diebessprache",
+    "DND5E.LanguagesUndercommon": "Gemeinsprache der Unterreiche",
+    "DND5E.LegAct": "Legendäre Aktionen",
+    "DND5E.LegActMax": "Maximale Legendäre Aktionen",
+    "DND5E.LegActN.few": "3. Legendäre Aktion",
+    "DND5E.LegActN.one": "1. Legendäre Aktion",
+    "DND5E.LegActN.other": "{n}. Legendäre Aktion",
+    "DND5E.LegActN.two": "2. Legendäre Aktion",
+    "DND5E.LegActRemaining": "Verbleibende Legendäre Aktionen",
+    "DND5E.LegRes": "Legendäre Resistenzen",
+    "DND5E.LegResMax": "Maximale Legendäre Resistenzen",
+    "DND5E.LegResN.few": "3. Legendäre Resistenz",
+    "DND5E.LegResN.one": "1. Legendäre Resistenz",
+    "DND5E.LegResN.other": "{n}. Legendäre Resistenz",
+    "DND5E.LegResN.two": "2. Legendäre Resistenz",
+    "DND5E.LegResRemaining": "Verbleibende Legendäre Resistenzen",
+    "DND5E.LegendaryActionLabel": "Legendäre Aktion",
+    "DND5E.Level": "Stufe",
+    "DND5E.LevelActionDecrease": "Stufenaufstieg",
+    "DND5E.LevelActionIncrease": "Stufenabstieg",
+    "DND5E.LevelCount": "{ordinal} Stufe",
+    "DND5E.LevelLimit": {
+        "Label": "Stufen Grenze",
+        "Max": "Maximale Stufe",
+        "Min": "Minimale Stufe"
+    },
+    "DND5E.LevelNumber": "Stufe {level}",
+    "DND5E.LevelPl": "Stufen",
+    "DND5E.LevelScaling": "Stufenanpassung",
+    "DND5E.LimitedUses": "Limitierte Nutzungen",
+    "DND5E.LimitedUsesAvailable": "Verbleibende Nutzungen",
+    "DND5E.LimitedUsesMax": "Maximale Nutzungen",
+    "DND5E.LimitedUsesPer": "Rückerlangung",
+    "DND5E.LimitedUsesPrompt": "Abfrage benutzen",
+    "DND5E.LimitedUsesPromptTooltip": "Wenn nicht aktiviert, wird die Abfrage beim verbrauchen von Nutzungen unterdrückt.",
+    "DND5E.Long": "Weit",
+    "DND5E.LongRest": "Lange Rast",
+    "DND5E.LongRestEpic": "Lange Rast (1 Stunde)",
+    "DND5E.LongRestGritty": "Lange Rast (7 Tage)",
+    "DND5E.LongRestHint": "Eine lange Rast einlegen? Bei einer langen Rast erhältst du Trefferpunkte, Trefferwürfel, Klassenressourcen, Aufladungen von Gegenständen mit begrenzten Nutzungen und Zauberplätze zurück.",
+    "DND5E.LongRestHintGroup": "Eine lange Rast einlegen? Bei einer langen Rast erhalten Gruppenmitglieder Trefferpunkte, Trefferwürfel, Klassenressourcen, Aufladungen von Gegenständen mit begrenzten Nutzungen und Zauberplätze zurück.",
+    "DND5E.LongRestHintGroupLegacy": "Eine lange Rast einlegen? Bei einer langen Rast erhalten Gruppenmitglieder Trefferpunkte, die Hälfte der maximalen Trefferwürfel, Klassenressourcen, Aufladungen von Gegenständen mit begrenzten Nutzungen und Zauberplätze zurück.",
+    "DND5E.LongRestHintLegacy": "Eine lange Rast einlegen? Bei einer langen Rast erhältst du Trefferpunkte, die Hälfte deiner maximalen Trefferwürfel, Klassenressourcen, Aufladungen von Gegenständen mit begrenzten Nutzungen und Zauberplätze zurück.",
+    "DND5E.LongRestNormal": "Lange Rast (8 Std.)",
+    "DND5E.LongRestOvernight": "Lange Rast (Neuer Tag)",
+    "DND5E.LongRestRecovery": "Rückerlangen nach Langer Rast",
+    "DND5E.LongRestResult": "{name} legt eine Lange Rast ein und erhält {health} TP und {dice} TW.",
+    "DND5E.LongRestResultHitDice": "{name} legt eine Lange Rast ein und erlangt {dice} Trefferwürfel zurück.",
+    "DND5E.LongRestResultHitPoints": "{name} legt eine Lange Rast ein und erlangt {health} Trefferpunkte zurück.",
+    "DND5E.LongRestResultShort": "{name} legt eine Lange Rast ein.",
+    "DND5E.Loot.Art": "Kunstgegenstand",
+    "DND5E.Loot.Gear": "Abenteuerausrüstung",
+    "DND5E.Loot.Gem": "Edelstein",
+    "DND5E.Loot.Junk": "Schrott",
+    "DND5E.Loot.Material": "Material",
+    "DND5E.Loot.Resource": "Ressource",
+    "DND5E.Loot.Treasure": "Schatz",
+    "DND5E.MagicalBonus": "Magischer Bonus",
+    "DND5E.Materials": "Material",
+    "DND5E.Max": "Max",
+    "DND5E.MaxCharacterLevelExceededWarn": "Charakter kann nicht über Stufe {max} hinaus aufsteigen.",
+    "DND5E.MaxClassLevelExceededWarn": "Klasse kann nicht über Stufe {max} hinaus aufsteigen.",
+    "DND5E.MaxClassLevelMinimumWarn": "Klasse muss mindestens eine Stufe haben.",
+    "DND5E.Maximum": "Maximum",
+    "DND5E.Minimum": "Minimum",
+    "DND5E.Modifier": "Modifikator",
+    "DND5E.ModuleArtConfigH": "Legt Module für Medien (z.B. für Illustrationen von Akteurporträts und Spielfiguren) fest.",
+    "DND5E.ModuleArtConfigL": "Medien bearbeiten",
+    "DND5E.ModuleArtConfigN": "Medien aus Modulen",
+    "DND5E.ModuleArtConfigPortraits": "Porträts",
+    "DND5E.ModuleArtConfigTokens": "Spielfiguren",
+    "DND5E.ModuleArtPriorityDecrease": "Priorität senken",
+    "DND5E.ModuleArtPriorityHint": "Mit den Pfeilen kann die Priorisierung der Art-Quellen angepasst werden. Wenn für einen Akteur Medien aus mehreren Quellen vorliegen, werden die mit der höchsten Priorität genutzt.",
+    "DND5E.ModuleArtPriorityIncrease": "Priorität erhöhen",
+    "DND5E.Movement": "Bewegung",
+    "DND5E.MovementAir": "Luft",
+    "DND5E.MovementBurrow": "Graben",
+    "DND5E.MovementClimb": "Klettern",
+    "DND5E.MovementConfig": "Bewegung einstellen",
+    "DND5E.MovementConfigHint": "Bearbeite die Bewegungsgeschwindigkeit und spezielle Bewegungsarten dieser Kreatur.",
+    "DND5E.MovementFly": "Fliegen",
+    "DND5E.MovementHover": "Schweben",
+    "DND5E.MovementLand": "Land",
+    "DND5E.MovementSpeeds": "Bewegungsrate",
+    "DND5E.MovementSwim": "Schwimmen",
+    "DND5E.MovementUnits": "Einheiten",
+    "DND5E.MovementWalk": "Laufen",
+    "DND5E.MovementWater": "Wasser",
+    "DND5E.Multiple": "Mehrfach",
+    "DND5E.Multiplier": "Multiplikator",
+    "DND5E.MythicActionLabel": "Mythische Aktion",
+    "DND5E.NPC": "NSC",
+    "DND5E.Name": "Charakter Name",
+    "DND5E.NameUnidentified": "Unidentifizierter Name",
+    "DND5E.NewDay": "Neuer Tag?",
+    "DND5E.NewDayHint": "Fähigkeiten mit begrenzten Nutzungen zurückerlangen, die pro Tag wiederaufladen?",
+    "DND5E.NoCharges": "Keine Ladungen",
+    "DND5E.NoSpellLevels": "Dieser Charakter hat keine Zaubererstufen, aber du kannst Zauber manuell hinzufügen.",
+    "DND5E.None": "Nichts",
+    "DND5E.NoneActionLabel": "Keine",
+    "DND5E.Normal": "Normal",
+    "DND5E.NotProficient": "Nicht geübt",
+    "DND5E.Notes": "Notizen",
+    "DND5E.Number": "Anzahl",
+    "DND5E.OtherFormula": "Andere Formel",
+    "DND5E.PactMagic": "Paktmagie",
+    "DND5E.Passive": "Passiv",
+    "DND5E.PassivePerception": "Passive Wahrnehmmung",
+    "DND5E.Period": "Periode",
+    "DND5E.PersonalityTraits": "Persönlichkeitsmerkmale",
+    "DND5E.Polymorph": "Verwandlung",
+    "DND5E.PolymorphAcceptSettings": "Eigene Einstellung",
+    "DND5E.PolymorphAddTemp": "Füge die TP des Ziels als Temporäre TP hinzu",
+    "DND5E.PolymorphCustomTransformation": "Eigene Verwandlung",
+    "DND5E.PolymorphEffectTransformation": "Effekte bei Verwandlung",
+    "DND5E.PolymorphKeepAE": "Behalte alle Effekte (überschreibt andere Effekt-Behalten-Optionen).",
+    "DND5E.PolymorphKeepBackgroundAE": "Behalte Effekte von Hintergründen",
+    "DND5E.PolymorphKeepBio": "Biographie behalten",
+    "DND5E.PolymorphKeepClass": "Behalte Übungsbonus (lässt Klasseneinträge im Bogen)",
+    "DND5E.PolymorphKeepClassAE": "Behalte Effekte von Klassen und Unterklassen",
+    "DND5E.PolymorphKeepEquipmentAE": "Behalte Effekte von Ausrüstung",
+    "DND5E.PolymorphKeepFeats": "Behalte Merkmale",
+    "DND5E.PolymorphKeepFeatureAE": "Behalte Effekte von Merkmalen",
+    "DND5E.PolymorphKeepHP": "Behalte TP & TW",
+    "DND5E.PolymorphKeepItems": "Ausrüstung behalten",
+    "DND5E.PolymorphKeepMental": "Behalte Mentale Attributswerte (Int, Wei, Cha)",
+    "DND5E.PolymorphKeepOriginAE": "Behalte Effekt vom Akteur (d.h. Effekte, die nicht an Zaubern, Merkmalen etc. hängen)",
+    "DND5E.PolymorphKeepOtherOriginAE": "Behalte Effekte die von anderen Akteuren stammen",
+    "DND5E.PolymorphKeepPhysical": "Behalte physikalische Attributswerte (Stä, Ges, Kon)",
+    "DND5E.PolymorphKeepSaves": "Behalte Rettungswürfe",
+    "DND5E.PolymorphKeepSelf": "Alles behalten (ändert nur Bild/Größe, z.B. für Selbstverkleidung)",
+    "DND5E.PolymorphKeepSkills": "Behalte Fertigkeiten",
+    "DND5E.PolymorphKeepSpellAE": "Behalte Effekte, die von eigenen Zaubern stammen",
+    "DND5E.PolymorphKeepSpells": "Behalte Zauber",
+    "DND5E.PolymorphKeepType": "Behalte Kreaturentyp",
+    "DND5E.PolymorphKeepVision": "Behalte Sicht (Charakter und Figuren)",
+    "DND5E.PolymorphMergeSaves": "Rettungswürfe zusammenführen (benutze den Besten)",
+    "DND5E.PolymorphMergeSkills": "Fertigkeiten zusammenführen (benutze den Besten)",
+    "DND5E.PolymorphPromptTitle": "Charakter-Verwandlung",
+    "DND5E.PolymorphRestoreTransformation": "Verwandlung aufheben",
+    "DND5E.PolymorphRevertNoOriginalActorWarn": "Ursprungsakteur mit Referenz '{reference}' nicht gefunden",
+    "DND5E.PolymorphRevertWarn": "Keine Erlaubnis, den verwandelten Zustand dieses Charakters umzukehren.",
+    "DND5E.PolymorphSelf": "Nur Aussehen",
+    "DND5E.PolymorphTmpClass": "Temporäre Klasse",
+    "DND5E.PolymorphTokens": "Alle verknüpften Figuren umwandeln?",
+    "DND5E.PolymorphWarn": "Keine Erlaubnis diesen Charakter zu verwandeln!",
+    "DND5E.PolymorphWildShape": "Tiergestalt",
+    "DND5E.Portrait": "Porträt",
+    "DND5E.PowerfulCritical": "Mächtige kritische Treffer",
+    "DND5E.Prepared": "Vorbereitet",
+    "DND5E.Prerequisites": {
+        "FIELDS": {
+            "prerequisites": {
+                "level": {
+                    "hint": "Charakter- oder Klassenstufe, die für die Auswahl dieses Merkmals beim Stufenaufstieg erforderlich ist.",
+                    "label": "Benötigte Stufe"
+                }
+            }
+        },
+        "Header": "Merkmal Voraussetzungen"
+    },
+    "DND5E.Price": "Preis",
+    "DND5E.Proficiency": "Übungsbonus",
+    "DND5E.ProficiencyBonus": "Übungsbonus",
+    "DND5E.ProficiencyConfigurationHint": "Übung und Boni bearbeiten.",
+    "DND5E.ProficiencyConfigureTitle": "{label} bearbeiten",
+    "DND5E.ProficiencyLevel": "Übungsstufe",
+    "DND5E.ProficiencyOther": "Sonstige",
+    "DND5E.Proficient": "Geübt",
+    "DND5E.Properties": "Eigenschaften",
+    "DND5E.PropertyBase": "Basis",
+    "DND5E.PropertyTotal": "Gesamt",
+    "DND5E.Public": "Öffentlich",
+    "DND5E.Quantity": "Anzahl",
+    "DND5E.QuantityAbbr": "Anz",
+    "DND5E.QuantityFormula": "Anzahl Formel",
+    "DND5E.QuantityRoll": "Anzahl der Würfe",
+    "DND5E.RANGE": {
+        "FIELDS": {
+            "range": {
+                "label": "Reichweite",
+                "long": {
+                    "hint": "Große Angriffsreichweite der Waffe, falls vorhanden.",
+                    "label": "Maximalreichweite"
+                },
+                "override": {
+                    "hint": "Verwende diese Werte für die Reichweite anstelle der Werte für das Item, wenn du diese Aktivität verwendest.",
+                    "label": "Überschreibe Reichweite"
+                },
+                "reach": {
+                    "label": "Reichweite"
+                },
+                "special": {
+                    "hint": "Beschreibung einer Speziellen Reichweite.",
+                    "label": "Spezielle Reichweite"
+                },
+                "units": {
+                    "hint": "Einheiten zur Messung der Reichweite.",
+                    "label": "Reichweiten Einheit"
+                },
+                "value": {
+                    "hint": "Wert der Reichweite in den angegebenen einheiten, falls zutreffend.",
+                    "label": "Reichweitenwert"
+                }
+            }
+        }
+    },
+    "DND5E.ROLL": "{'Range': {'Label': 'Würfelspanne', 'Maximum': 'Maximaler Wurf', 'Minimum': 'Minimaler Wurf'}, 'Section': '{label} Würfe'}",
+    "DND5E.RacialTraits": "Volkseigenschaften",
+    "DND5E.Range": "Reichweite",
+    "DND5E.RangeDistance": "Distanz",
+    "DND5E.RangeLong": "Maximalreichweite",
+    "DND5E.RangeNormal": "Grundreichweite",
+    "DND5E.RangeUnits": "Reichweitentyp oder Einheit",
+    "DND5E.Rarity": "Seltenheit",
+    "DND5E.Reaction": "Reaktion",
+    "DND5E.ReactionAbbr": "R",
+    "DND5E.ReactionPl": "Reaktionen",
+    "DND5E.Recharge": "Aufladen",
+    "DND5E.Recovery": "Wiederherst.",
+    "DND5E.RecoveryFormula": "Formel zum Wiederaufladen",
+    "DND5E.RequiredMaterials": "Benötigte Materialien",
+    "DND5E.Requirements": "Voraussetzungen",
+    "DND5E.Resistances": "Resistenz",
+    "DND5E.ResourceLabel": "Name",
+    "DND5E.ResourceMax": "Ressourcenmaximum",
+    "DND5E.ResourcePrimary": "Ressource 1",
+    "DND5E.ResourceSecondary": "Ressource 2",
+    "DND5E.ResourceTertiary": "Ressource 3",
+    "DND5E.ResourceValue": "Ressourcenwert",
+    "DND5E.Resources": "Ressourcen",
+    "DND5E.Rest": "Rast",
+    "DND5E.RestL": "L. Rast",
+    "DND5E.RestS": "K. Rast",
+    "DND5E.Ritual": "Ritual",
+    "DND5E.RitualAbbr": "R",
+    "DND5E.Roll": "Wurf",
+    "DND5E.RollConfiguration": {
+        "Configuration": "Konfiguration",
+        "Rolls": "Würfe",
+        "Title": "Wurf Konfigurieren"
+    },
+    "DND5E.RollExample": "z.B. +1W4",
+    "DND5E.RollMode": "Wurf Modus",
+    "DND5E.RollSituationalBonus": "Situativer Bonus?",
+    "DND5E.Rule": {
+        "Tooltip": "Tooltip",
+        "Type": {
+            "Condition": "Zustand",
+            "Label": "Regel-Typ",
+            "Rule": "Regel"
+        }
+    },
+    "DND5E.SAVE": {
+        "FIELDS": {
+            "damage": {
+                "label": "Rettungswurf Schaden",
+                "onSave": {
+                    "Full": "Vollständiger Schaden",
+                    "Half": "Halber Schaden",
+                    "None": "Kein Schaden",
+                    "hint": "Wie viel Schaden sollte bei einem Erfolgreichen Rettungswurf zugefügt werden?",
+                    "label": "Schaden bei Erfolg"
+                },
+                "parts": {
+                    "hint": "Einzelne Schadensbestandteile dem Wurf hinzufügen.",
+                    "label": "Schadensbestandteil"
+                }
+            },
+            "effects": {
+                "onSave": {
+                    "hint": "Dieser Effekt wird immer angewendet, auch wenn das Ziel seinen Rettungswurf schafft.",
+                    "label": "Immer Anwenden"
+                }
+            },
+            "save": {
+                "ability": {
+                    "hint": "Attribut, das gewürfelt werden muss, um zu versuchen, den Rettungswurf zu bestehen.",
+                    "label": "Herausforderndes Attribut"
+                },
+                "dc": {
+                    "CustomFormula": "Eigene Formel",
+                    "DefaultFormula": "8 + @mod + @prof",
+                    "calculation": {
+                        "hint": "Methode oder Attribut, das zur Berechnung des Schwierigkeitsgrades verwendet wird.",
+                        "label": "SG Berechnung"
+                    },
+                    "formula": {
+                        "hint": "Eigene Formel oder fester Wert zur Definition Rettungs-SG.",
+                        "label": "SG Formel"
+                    },
+                    "label": "Schwierigkeitsgrad"
+                },
+                "label": "Rettungswurf Details"
+            }
+        },
+        "OnSave": "Bei Erfolg",
+        "Title": {
+            "one": "Rettungswurf",
+            "other": "Rettungswürfe"
+        }
+    },
+    "DND5E.SKILL": "{'SECTIONS': {'Details': '{label} Details', 'Bonuses': {'Label': '{label} Boni', 'Hint': 'Diese Boni gelten für passive Werte und Proben, die mit {label} durchgeführt werden.'}, 'Global': {'Label': 'Globale Boni', 'Hint': 'Diese Boni gelten für Proben, die mit einer beliebigen Fertigkeit durchgeführt werden.'}}}",
+    "DND5E.SOURCE": {
+        "Action": {
+            "Configure": "Quelle Konfigurieren"
+        },
+        "Display": {
+            "Full": "{book} {page}",
+            "Page": "S. {page}"
+        },
+        "FIELDS": {
+            "source": {
+                "book": {
+                    "label": "Buch"
+                },
+                "custom": {
+                    "label": "Eigenes Label"
+                },
+                "label": "Quelle",
+                "license": {
+                    "label": "Lizenz"
+                },
+                "page": {
+                    "label": "Seite/Abschnitt"
+                },
+                "revision": {
+                    "label": "Revision"
+                },
+                "rules": {
+                    "label": "Regelversion"
+                },
+                "uuid": {
+                    "label": "Originalquelle"
+                }
+            }
+        }
+    },
+    "DND5E.SUMMON": {
+        "Action": {
+            "Place": "Beschwörungen Platzieren",
+            "Summon": "Beschwören",
+            "View": "Beschwörung Anzeigen"
+        },
+        "CreatureChanges": {
+            "Hint": "Anpassungen, die an der beschworenen Kreatur vorgenommen werden. Alle @ Referenzen, die in den folgenden Formeln verwendet werden, basieren auf den Werten des Beschwörers. Die Werte beschworener Kreaturen können mit @summon abgerufen werden (z. B. @summon.attributes.hd.max, um die Trefferwürfelzahl der Kreatur abzurufen).",
+            "Label": "Kreatur anpassungen"
+        },
+        "FIELDS": {
+            "bonuses": {
+                "ac": {
+                    "hint": "Bonus auf die Rüstungsklasse, die für die beschworene Kreatur festgelegt wurde, zusätzlich zu dem, was in ihrem Werteblock angegeben ist.",
+                    "label": "Bonus Rüstungsklasse"
+                },
+                "attackDamage": {
+                    "hint": "Zusätzlicher Schaden durch die Angriffe der Kreatur.",
+                    "label": "Bonus Angriffsschaden"
+                },
+                "hd": {
+                    "hint": "Fügt der Kreatur zusätzliche Trefferwürfel hinzu, zusätzlich zu denen, die sich aus der TP-Formel in ihrem Werteblock ergeben. Kann nur bei der Beschwörung von NPC-Akteuren verwendet werden.",
+                    "label": "Bonus Trefferwürfel"
+                },
+                "healing": {
+                    "hint": "Zusätzliche Heilung durch heilende Fähigkeiten.",
+                    "label": "Bonus Heilung"
+                },
+                "hp": {
+                    "hint": "Der Kreatur wurden zusätzlich zu den Angaben in ihrem Werteblock weitere Trefferpunkte hinzugefügt.",
+                    "label": "Bonus Trefferpunkte"
+                },
+                "saveDamage": {
+                    "hint": "Zusätzlicher Schaden, der durch die Fähigkeitene der Kreatur verursacht wird und Rettungswürfe erfordert.",
+                    "label": "Bonus Rettungswurfschaden"
+                }
+            },
+            "creatureSizes": {
+                "hint": "Beschworene Kreaturen und Toen werden auf diese Größe geändert. Wenn mehr als eine Größe ausgewählt wird, kann der Spieler beim Beschwören aus diesen Größen wählen.",
+                "label": "Kreaturengröße"
+            },
+            "creatureTypes": {
+                "hint": "Die beschworene Kreatur wird in diesen Typ geändert. Wenn mehr als ein Typ ausgewählt ist, kann der Spieler beim Beschwören aus diesen Typen auswählen.",
+                "label": "Kreaturentyp"
+            },
+            "match": {
+                "attacks": {
+                    "hint": "Passt die Trefferwerte der Angriffe der beschworenen Kreatur an die des Beschwörers an.",
+                    "label": "Angriffe Angleichen"
+                },
+                "proficiency": {
+                    "hint": "Passt die Übungen der beschworenen Kreatur an die des Beschwörers an.",
+                    "label": "Übungen angleichen"
+                },
+                "saves": {
+                    "hint": "Passt die Rettungswürfe SGs für die Fähigkeiten der beschworenen Kreatur an die des Beschwörers an.",
+                    "label": "Rettungswürfe angleichen"
+                }
+            },
+            "profiles": {
+                "FIELDS": {
+                    "count": {
+                        "label": "Anzahl"
+                    },
+                    "cr": {
+                        "abbr": "HG",
+                        "hint": "Maximaler HG der beschworenen Kreatur.",
+                        "label": "Herausforderungsgrad"
+                    },
+                    "level": {
+                        "hint": "Stufenbereich, der für die Verwendung dieses Profils erforderlich ist.",
+                        "label": "Stufengrenze",
+                        "max": {
+                            "label": "Maximale Stufe"
+                        },
+                        "min": {
+                            "label": "Minimale Stufe"
+                        }
+                    },
+                    "name": {
+                        "hint": "Name des Profils, der im Nutzungsdialog angezeigt wird.",
+                        "label": "Anzeigename"
+                    },
+                    "types": {
+                        "hint": "Liste der Kreaturentypen, aus denen die beschworene Kreatur ausgewählt werden kann.",
+                        "label": "Kreaturentyp"
+                    },
+                    "uuid": {
+                        "label": "Verlinkte Kreatur"
+                    }
+                },
+                "label": "Beschwörungs Profil"
+            },
+            "summon": {
+                "identifier": {
+                    "hint": "ID, die verwendet wird, um zu bestimmen, ob die Charakterstufe oder eine bestimmte Klassenstufe für die Begrenzung der Verzauberungsstufe verwendet werden soll.",
+                    "label": "Klassen-ID"
+                },
+                "label": "Beschwörung Details",
+                "mode": {
+                    "CR": "Durch Herausforderungsgrad & Typ",
+                    "Direct": "Durch direkte Verlinkung",
+                    "hint": "Legt fest, wie die Kreaturen, die beschworen werden sollen, spezifiziert werden.",
+                    "label": "Modus"
+                },
+                "prompt": {
+                    "hint": "Wenn nicht aktiviert, wird die Abfrage zum platzieren einer Beschwörung unterdrückt. Die Spieler können weiterhin über die Chatkarte beschwören.",
+                    "label": "Beschwörungsabfrage"
+                }
+            }
+        },
+        "ItemChanges": {
+            "Hint": "Anpassungen an den Items der beschworenen Kreatur.",
+            "Label": "Item Anpassungen"
+        },
+        "Profile": {
+            "Action": {
+                "Create": "Erstelle Profil",
+                "Delete": "Entferne Profil"
+            },
+            "ChallengeRatingLabel": "Herausforderungsgrad von {cr} oder niedriger",
+            "DropHint": "Kreatur hier ablegen",
+            "Empty": "Klicke den <i class=\"fas fa-plus\"></i> Knopf oben um ein Profil zu erstellen.",
+            "EmptyDrop": "Klicke den <i class=\"fas fa-plus\"></i> Knopf oben um ein Profil zu erstellen oder lege hier eine Kreatur zum beschwören ab",
+            "Label": "Beschwörungs Profil"
+        },
+        "SECTIONS": {
+            "Changes": "Änderungen",
+            "Profiles": "Profile",
+            "Summoning": "Beschwörung"
+        },
+        "Title": "Beschwören",
+        "Warning": {
+            "CRV11": "Beschwörungen basierend auf dem Herausforderungsgrad der Kreaturen, funktioniert nur in Foundry V12 oder höher.",
+            "CreateActor": "Sie müssen über die Berechtigung 'Neue Akteure erstellen' verfügen, um direkt aus einem Kompendium beschwören zu können.",
+            "NoActor": "Akteur mit der UUID '{uuid}' kann nicht gefunden werden, um zu beschwören.",
+            "NoOwnership": "Du musst Eigentümer von '{Akteur}' sein, um ihn beschwören zu können.",
+            "NoProfile": "Das Beschwörungsprofil {profileId} für '{item}' konnte nicht gefunden werden.",
+            "Wildcard": "Sie müssen über die Berechtigung 'Dateien durchsuchen' verfügen, um Kreaturen mit Platzhalterbildern zu beschwören."
+        }
+    },
+    "DND5E.SaveBonus": "Rettungswurfbonus",
+    "DND5E.SaveDC": "SG {dc} {ability}",
+    "DND5E.SaveGlobalBonusHint": "Dieser Bonus gilt für alle Rettungswürfe dieses Akteurs.",
+    "DND5E.SavePromptTitle": "{ability} Rettungswurf",
+    "DND5E.SavingThrow": "Rettungswurf",
+    "DND5E.SavingThrowDC": "SG {dc} {ability}-Rettungswurf",
+    "DND5E.SavingThrowRoll": "Werfe {ability}-Rettungswurf",
+    "DND5E.ScalingFormula": "Skalierungsformel",
+    "DND5E.ScalingMode": "Skalierungsmodus",
+    "DND5E.ScalingValue": "Skalierungswert",
+    "DND5E.School": "Schule",
+    "DND5E.SchoolAbj": "Bannmagie",
+    "DND5E.SchoolCon": "Beschwörung",
+    "DND5E.SchoolDiv": "Erkenntnismagie",
+    "DND5E.SchoolEnc": "Verzauberung",
+    "DND5E.SchoolEvo": "Hervorrufung",
+    "DND5E.SchoolIll": "Illusion",
+    "DND5E.SchoolNec": "Nekromantie",
+    "DND5E.SchoolTrs": "Verwandlung",
+    "DND5E.Scroll": {
+        "CreateFrom": "Schriftrolle von {spell} erstellen",
+        "CreateScroll": "Schriftrolle erstellen",
+        "Details": "Schriftrollendetails",
+        "Explanation": {
+            "Complete": "Komplett",
+            "Hint": "Menge der Regeln zur Verwendung von Zauberrollen, die in die erstellte Schriftrolle aufgenommen werden.",
+            "Label": "Erklärung",
+            "Reference": "Referenz"
+        },
+        "RequiresConcentration": "Benötigt Konzentration",
+        "SaveDC": "Zauber SG",
+        "Values": "Zauber Werte"
+    },
+    "DND5E.SenseBlindsight": "Blindsicht",
+    "DND5E.SenseDarkvision": "Dunkelsicht",
+    "DND5E.SenseSpecial": "Spezielle Sinne",
+    "DND5E.SenseTremorsense": "Erschütterungssinn",
+    "DND5E.SenseTruesight": "Wahrsicht",
+    "DND5E.SenseUnits": "Einheiten",
+    "DND5E.Senses": "Sinne",
+    "DND5E.SensesConfig": "Sinne bearbeiten",
+    "DND5E.SensesConfigHint": "Bearbeite spezielle sensorische Wahrnehmungsfähigkeiten, die dieser Charakter besitzt.",
+    "DND5E.Shape": "Form",
+    "DND5E.SheetClassCharacter": "Standard 5e Charakterbogen",
+    "DND5E.SheetClassCharacterLegacy": "Legacy 5e Charakterbogen",
+    "DND5E.SheetClassClassSummary": "Standard 5e Klassenübersichtsbogen",
+    "DND5E.SheetClassContainer": "Standard 5e Behälterbogen",
+    "DND5E.SheetClassContainerLegacy": "Legacy 5e Behälterbogen",
+    "DND5E.SheetClassGroup": "Standard 5e Gruppenbogen",
+    "DND5E.SheetClassItem": "Standard 5e Gegenstandsbogen",
+    "DND5E.SheetClassItemLegacy": "Legacy 5e Itembogen",
+    "DND5E.SheetClassJournalEntry": "Standard 5e Notizbogen",
+    "DND5E.SheetClassMapLocation": "Standard 5e Kartenbogen",
+    "DND5E.SheetClassNPC": "Standard 5e NSC-Bogen",
+    "DND5E.SheetClassNPCLegacy": "Legacy 5e NSC-Bogen",
+    "DND5E.SheetClassRule": "Standard 5e Regelbogen",
+    "DND5E.SheetClassSpellList": "Standard 5e Zauberlistenbogen",
+    "DND5E.SheetClassToken": "Standard 5e Figurbogen",
+    "DND5E.SheetClassVehicle": "Standard 5e Fahrzeugbogen",
+    "DND5E.SheetModeEdit": "Bearbeiten",
+    "DND5E.SheetModePlay": "Spielen",
+    "DND5E.ShortRest": "Kurze Rast",
+    "DND5E.ShortRestEpic": "Kurze Rast (5 Min.)",
+    "DND5E.ShortRestGritty": "Kurze Rast (8 Std.)",
+    "DND5E.ShortRestHint": "Kurze Rast einlegen? Bei einer kurzen Rast können verbleibende Trefferwürfel ausgegeben und Ressourcen zurückgewonnen werden.",
+    "DND5E.ShortRestHintGroup": "Kurze Rast einlegen? Bei einer kurzen Rast können Gruppenmitglieder Trefferwürfel nutzen und manche Gegenstandsnutzungen zurückerlangen.",
+    "DND5E.ShortRestNoHD": "Keine Trefferwürfel mehr übrig",
+    "DND5E.ShortRestNormal": "Kurze Rast (1 Std.)",
+    "DND5E.ShortRestOvernight": "Kurze Rast (Neuer Tag)",
+    "DND5E.ShortRestRecovery": "Rückerlangen nach Kurzer Rast",
+    "DND5E.ShortRestResult": "{name} legt eine kurze Rast ein und gibt {dice} TW aus um {health} TP zurückzubekommen.",
+    "DND5E.ShortRestResultShort": "{name} legt eine kurze Rast ein.",
+    "DND5E.ShortRestSelect": "Wähle Würfel",
+    "DND5E.Size": "Größe",
+    "DND5E.SizeGargantuan": "Gigantisch",
+    "DND5E.SizeGargantuanAbbr": "Gi",
+    "DND5E.SizeHuge": "Riesig",
+    "DND5E.SizeHugeAbbr": "Ri",
+    "DND5E.SizeLarge": "Gross",
+    "DND5E.SizeLargeAbbr": "Gr",
+    "DND5E.SizeMedium": "Mittelgross",
+    "DND5E.SizeMediumAbbr": "Mi",
+    "DND5E.SizeSmall": "Klein",
+    "DND5E.SizeSmallAbbr": "Ll",
+    "DND5E.SizeTiny": "Winzig",
+    "DND5E.SizeTinyAbbr": "Wi",
+    "DND5E.Skill": "Fertigkeit",
+    "DND5E.SkillAcr": "Akrobatik",
+    "DND5E.SkillAni": "Mit Tieren umgehen",
+    "DND5E.SkillArc": "Arkane Kunde",
+    "DND5E.SkillAth": "Athletik",
+    "DND5E.SkillBonusCheck": "Probenbonus",
+    "DND5E.SkillBonusPassive": "Passiver Bonus",
+    "DND5E.SkillBonuses": "Fertigkeitsboni",
+    "DND5E.SkillConfigurationHint": "Übung in Fertigkeit und Boni bearbeiten.",
+    "DND5E.SkillConfigure": "Fertigkeit bearbeiten",
+    "DND5E.SkillConfigureTitle": "{skill} bearbeiten",
+    "DND5E.SkillDec": "Täuschen",
+    "DND5E.SkillGlobalBonusCheckHint": "Dieser Bonus gilt für alle Fertigkeitsproben dieses Akteurs.",
+    "DND5E.SkillHis": "Geschichte",
+    "DND5E.SkillIns": "Motiv erkennen",
+    "DND5E.SkillInv": "Nachforschungen",
+    "DND5E.SkillItm": "Einschüchtern",
+    "DND5E.SkillMed": "Heilkunde",
+    "DND5E.SkillModifierHint": "{skill}-Modifikator",
+    "DND5E.SkillNat": "Naturkunde",
+    "DND5E.SkillPassiveHint": "Passive {skill}",
+    "DND5E.SkillPassiveScore": "Passiver {skill}wert",
+    "DND5E.SkillPassiveSpecificHint": "Passive {ability} ({skill})",
+    "DND5E.SkillPassives": "Passive Fertigkeiten",
+    "DND5E.SkillPer": "Überzeugen",
+    "DND5E.SkillPrc": "Wahrnehmung",
+    "DND5E.SkillPrf": "Auftreten",
+    "DND5E.SkillPromptTitle": "{skill} Fertigkeitswurf",
+    "DND5E.SkillRel": "Religion",
+    "DND5E.SkillSlt": "Fingerfertigkeit",
+    "DND5E.SkillSte": "Heimlichkeit",
+    "DND5E.SkillSur": "Überlebenskunst",
+    "DND5E.Skills": "Fertigkeiten",
+    "DND5E.SkillsConfig": "Fertigkeiten bearbeiten",
+    "DND5E.Skin": "Haut",
+    "DND5E.Skip": "Überspringen",
+    "DND5E.Special": "Spezial",
+    "DND5E.SpecialHint": "Spezialwerte durch Semikolons getrennt.",
+    "DND5E.SpecialTraits": "Spezielle Merkmale",
+    "DND5E.Species": {
+        "Add": "Spezies Hinzufügen",
+        "Features": "Spezies Merkmal",
+        "Label": "Spezies",
+        "Name": "Spezies Name"
+    },
+    "DND5E.Speed": "Bewegungswert",
+    "DND5E.SpeedConditions": "Bewegungsbedingung",
+    "DND5E.SpeedSpecial": "Spez. Bewegungsart",
+    "DND5E.SpellAbility": "Zauberattribut",
+    "DND5E.SpellAbilitySet": "Festlegen als Primäres Zauberattribut",
+    "DND5E.SpellAdd": "Zauber hinzufügen",
+    "DND5E.SpellCantrip": "Zaubertrick",
+    "DND5E.SpellCastConsume": "Zauberplatz verbrauchen?",
+    "DND5E.SpellCastNoSlots": "Kein freier Zauberplatz um diesen Spruch zu wirken",
+    "DND5E.SpellCastNoSlotsLeft": "Du hast keine Verfügbaren Zauberplätze um {name} zu wirken!",
+    "DND5E.SpellCastTime": "Zauberzeit",
+    "DND5E.SpellCastUpcast": "Wirke auf Grad",
+    "DND5E.SpellCastingHeader": "Zauberwirken",
+    "DND5E.SpellComponent": "Zauberkomponenten",
+    "DND5E.SpellComponents": "Zauber Komponenten",
+    "DND5E.SpellCreate": "Zauber erschaffen",
+    "DND5E.SpellDC": "Zauber SG",
+    "DND5E.SpellDetails": "Zauber Details",
+    "DND5E.SpellEffects": "Zauber Effekte",
+    "DND5E.SpellHeader": {
+        "Formula": "Formel",
+        "Range": "Reichweite",
+        "Roll": "Wurf",
+        "School": "Schule",
+        "Target": "Ziel",
+        "Time": "Zeit"
+    },
+    "DND5E.SpellLevel": "Zaubergrad",
+    "DND5E.SpellLevel0": "Zaubertrick",
+    "DND5E.SpellLevel1": "1. Grad",
+    "DND5E.SpellLevel2": "2. Grad",
+    "DND5E.SpellLevel3": "3. Grad",
+    "DND5E.SpellLevel4": "4. Grad",
+    "DND5E.SpellLevel5": "5. Grad",
+    "DND5E.SpellLevel6": "6. Grad",
+    "DND5E.SpellLevel7": "7. Grad",
+    "DND5E.SpellLevel8": "8. Grad",
+    "DND5E.SpellLevel9": "9. Grad",
+    "DND5E.SpellLevelPact": "Paktzauberplatz",
+    "DND5E.SpellLevelSlot": "{level} ({n} Plätze)",
+    "DND5E.SpellLevels": "Zaubergrade",
+    "DND5E.SpellMaterials": "Zaubermaterialien",
+    "DND5E.SpellMaterialsConsumed": "Material verbrauchen",
+    "DND5E.SpellMaterialsCost": "Materialkosten",
+    "DND5E.SpellMaterialsDescription": "Materialbeschreibung",
+    "DND5E.SpellMaterialsSupply": "Materialvorrat",
+    "DND5E.SpellName": "Zaubername",
+    "DND5E.SpellNone": "Nichts",
+    "DND5E.SpellPrepAlways": "Immer verfügbar",
+    "DND5E.SpellPrepAtWill": "Nach Belieben",
+    "DND5E.SpellPrepInnate": "Angeborenes Zauberwirken",
+    "DND5E.SpellPrepPrepared": "Vorbereitet",
+    "DND5E.SpellPrepRitual": "Nur Rituale",
+    "DND5E.SpellPreparation": {
+        "Label": "Zaubervorbereitung",
+        "Formula": "Vorbereitungs-Formel",
+        "Mode": "Zaubervorbereitungsmodus"
+    },
+    "DND5E.SpellPrepared": "Vorbereitet",
+    "DND5E.SpellProgArt": "Artifizient",
+    "DND5E.SpellProgAvailable": "Verfügbare Plätze",
+    "DND5E.SpellProgFull": "Vollzauberer",
+    "DND5E.SpellProgHalf": "Halbzauberer",
+    "DND5E.SpellProgLeveled": "Stufenbasiertes Zaubern",
+    "DND5E.SpellProgOverride": "Überschreibe Plätze",
+    "DND5E.SpellProgPact": "Paktmagie",
+    "DND5E.SpellProgThird": "Drittelzauberer",
+    "DND5E.SpellProgression": "Zauberfortschritt",
+    "DND5E.SpellSchool": "Zauberschule",
+    "DND5E.SpellScroll": "Zauberspruchrolle",
+    "DND5E.SpellSlotExpended": "Verbrauchter Zauberplatz",
+    "DND5E.SpellSlotN.few": "{n}. Zauberplatz",
+    "DND5E.SpellSlotN.one": "{n}. Zauberplatz",
+    "DND5E.SpellSlotN.other": "{n}. Zauberplatz",
+    "DND5E.SpellSlotN.two": "{n}. Zauberplatz",
+    "DND5E.SpellSlotsConfig": "Zauberplätze Konfigurieren",
+    "DND5E.SpellSlotsN.few": "{n}. Grad Zauberplätze",
+    "DND5E.SpellSlotsN.one": "{n}. Grad Zauberplätze",
+    "DND5E.SpellSlotsN.other": "{n}. Grad Zauberplätze",
+    "DND5E.SpellSlotsN.two": "{n}. Grad Zauberplätze",
+    "DND5E.SpellSlotsPact": "Pakt-Zauberplätze",
+    "DND5E.SpellSourceClass": "Quellenklasse",
+    "DND5E.SpellTag": "Zauber-Tag",
+    "DND5E.SpellTarget": "Zauberziel",
+    "DND5E.SpellUnprepared": "Unvorbereitet",
+    "DND5E.SpellUsage": "Zaubernutzung",
+    "DND5E.Spellbook": "Zauberbuch",
+    "DND5E.SpellcasterLevel": "Zauberwirkerstufe",
+    "DND5E.Spellcasting": "Zauberwirken",
+    "DND5E.SpellcastingClass": "{class} Zauberwirken",
+    "DND5E.SpellsSearch": "Zauber durchsuchen",
+    "DND5E.Spent": "Ausgegeben",
+    "DND5E.StartingEquipment": {
+        "Action": {
+            "AddEntry": "Eintrag hinzufügen",
+            "Configure": "Startausrüstung konfigurieren",
+            "RemoveEntry": "Eintrag entfernen"
+        },
+        "Choice": {
+            "Armor": "Rüstung wählen",
+            "Focus": "Zauberfokus wählen",
+            "Tool": "Werkzeug wählen",
+            "Weapon": "Waffe wählen"
+        },
+        "DropHint": "Item hier ablegen zum verlinken",
+        "IfProficient": "Wenn geübt",
+        "Operator": {
+            "AND": "Alle aus…",
+            "OR": "Eins aus…"
+        },
+        "RequireProficiency": "Benötigt Übung",
+        "SpecificItem": "Spezifisches Item",
+        "Title": "Startausrüstung",
+        "Warning": {
+            "Depth": "Bei der Startausrüstung sind nur drei Verschachtelung erlaubt.",
+            "ItemTypeInvalid": "{type} Items können nicht zur Startausrüstung hinzugefügt werden."
+        },
+        "Wealth": {
+            "Hint": "Formel in GM, die anstelle der Startausrüstung verwendet werden kann.",
+            "Label": "Startvermögen"
+        }
+    },
+    "DND5E.SubclassAdd": "Unterklasse Hinzufügen",
+    "DND5E.SubclassAssignmentError": "{class} hat schon eine Unterklasse. Bestehende Unterklasse '{subclass}' entfernen, bevor eine neue hinzugefügt wird.",
+    "DND5E.SubclassDuplicateError": "Unterklasse mit ID {identifier} existiert an diesem Akteur bereits.",
+    "DND5E.SubclassIdentifierHint": "Diese ID sollte der Oberklasse entsprechen, um sicherzustellen, dass beide richtig verknüpft sind.",
+    "DND5E.SubclassMismatchWarn": "Unterklasse {name} verfügt über keine Klasse, die zur ID '{class}' passt.",
+    "DND5E.SubclassName": "Name der Unterklasse",
+    "DND5E.Subtype": "Unterart",
+    "DND5E.Summoning": {
+        "Action": {
+            "Add": "Profil hinzufügen",
+            "Configure": "Beschwörungen konfigurieren",
+            "Place": "Beschwörungen platzieren",
+            "Remove": "Profil entfernen",
+            "Summon": "Beschwören",
+            "View": "Beschwörung ansehen"
+        },
+        "Bonuses": {
+            "ArmorClass": {
+                "Hint": "Bonus auf die Rüstungsklasse der beschworenen Kreatur zusätzlich zu den Angaben in ihrem Statblock.",
+                "Label": "Bonus-Rüstungsklasse"
+            },
+            "Attack": {
+                "Hint": "Zusätzlicher Schaden, der durch die Angriffe der Kreatur verursacht wird.",
+                "Label": "Bonus-Angriffsschaden"
+            },
+            "Healing": {
+                "Hint": "Zusätzliche Heilung durch Heilfähigkeiten.",
+                "Label": "Bonus-Heilung"
+            },
+            "HitDice": {
+                "Hint": "Zusätzliche Trefferwürfel, die der Kreatur zusätzlich zu den Werten aus der TP-Formel in ihrem Statblock hinzugefügt werden. Kann nur bei der Beschwörung von NPC-Akteuren verwendet werden.",
+                "Label": "Bonus-Trefferwürfel"
+            },
+            "HitPoints": {
+                "Hint": "Zusätzliche Trefferpunkte, die der Kreatur zusätzlich zu den in ihrem Statblock angegebenen hinzugefügt werden.",
+                "Label": "Bonus-Trefferpunkte"
+            },
+            "Saves": {
+                "Hint": "zusätzlicher Schaden, der durch die Fähigkeiten der Kreatur verursacht wird, die Rettungswürfe erfordern.",
+                "Label": "Bonus-Rettungswurfschaden"
+            }
+        },
+        "Configuration": "Beschwörung konfigurieren",
+        "Count": {
+            "Label": "Anzahl"
+        },
+        "CreatureChanges": {
+            "Hint": "Anpassungen, die an der beschworenen Kreatur vorgenommen werden. Alle @ Referenzen, die in den folgenden Formeln verwendet werden, basieren auf den Werten des Beschwörers.",
+            "Label": "Kreatur anpassungen"
+        },
+        "CreatureSizes": {
+            "Hint": "Die beschworene Kreatur und der Token werden in diese Größe geändert. Wenn mehr als eine Größe ausgewählt wurde, kann der Spieler bei der Beschwörung zwischen diesen Größen wählen.",
+            "Label": "Größe der Kreaturen"
+        },
+        "CreatureTypes": {
+            "Hint": "Die beschworene Kreatur wird in diesen Typ umgewandelt. Wenn mehr als ein Typ ausgewählt wurde, kann der Spieler bei der Beschwörung zwischen diesen Typen wählen.",
+            "Label": "Kreaturentypen"
+        },
+        "DisplayName": "Anzeigename",
+        "DropHint": "Kreatur hier ablegen",
+        "ItemChanges": {
+            "Hint": "Anpassungen an den Items der beschworenen Kreatur.",
+            "Label": "Item Anpassungen"
+        },
+        "Label": "Beschwörung",
+        "Level": {
+            "Hint": "Stufenbereich, der für die Verwendung dieses Profils erforderlich ist.",
+            "IdentifierHint": "ID, mit der festgelegt wird, ob die Charakterstufe oder eine bestimmte Klassenstufe für die Begrenzung des Profils verwendet werden soll."
+        },
+        "Match": {
+            "Attacks": {
+                "Hint": "Passt die Trefferwerte der Angriffe der beschworenen Kreatur an die des Beschwörers an.",
+                "Label": "Angriffe angleichen"
+            },
+            "Proficiency": {
+                "Hint": "Passt die Übungen der beschworenen Kreatur an die des Beschwörers an.",
+                "Label": "Übungen angleichen"
+            },
+            "Saves": {
+                "Hint": "Passt die Rettungswürfe SGs für die Fähigkeiten der beschworenen Kreatur an die des Beschwörers an.",
+                "Label": "Rettungswürfe angleichen"
+            }
+        },
+        "Mode": {
+            "CR": "Nach Herausforderungsgrad und Typ",
+            "Direct": "Mit direktem Link",
+            "Hint": "Legt fest, wie die Kreaturen, die beschworen werden sollen, spezifiziert werden.",
+            "Label": "Modus"
+        },
+        "Profile": {
+            "ChallengeRatingLabel": "Herausforderungsgrad von {cr} oder niedriger",
+            "Empty": "Klicken Sie oben, um ein Profil hinzuzufügen.",
+            "EmptyDrop": "Klicken Sie oben, um ein Profil hinzuzufügen, oder legen sie eine Kreatur ab.",
+            "Label": "Beschwörungs Profil",
+            "LabelPl": "Beschwörungen Profile"
+        },
+        "Prompt": {
+            "Hint": "Wenn nicht aktiviert, wird die Abfrage zum platzieren einer Beschwörung unterdrückt. Die Spieler können weiterhin über die Chatkarte beschwören.",
+            "Label": "Beschwörungsabfrage"
+        },
+        "Warning": {
+            "CRV11": "Beschwörungen basierend auf dem Herausforderungsgrad der Kreaturen, funktioniert nur in Foundry V12 oder höher.",
+            "CreateActor": "Sie müssen über die Berechtigung 'Neue Akteure erstellen' verfügen, um direkt aus einem Kompendium beschwören zu können.",
+            "NoActor": "Akteur mit der UUID '{uuid}' kann nicht gefunden werden, um zu beschwören.",
+            "NoOwnership": "Du musst Eigentümer von '{Akteur}' sein, um ihn beschwören zu können.",
+            "NoProfile": "Das Beschwörungsprofil {profileId} für '{item}' konnte nicht gefunden werden.",
+            "Wildcard": "Sie müssen über die Berechtigung 'Dateien durchsuchen' verfügen, um Kreaturen mit Platzhalterbildern zu beschwören."
+        }
+    },
+    "DND5E.Supply": "Versorgung",
+    "DND5E.Suppressed": "Unterdrückt",
+    "DND5E.TARGET": {
+        "Action": {
+            "PlaceTemplate": "Platziere Messschablone"
+        },
+        "FIELDS": {
+            "target": {
+                "affects": {
+                    "choice": {
+                        "hint": "Kann der Benutzer bei der Auswahl eines Bereichs entscheiden, wer davon betroffen ist?",
+                        "label": "Wähle Ziele"
+                    },
+                    "count": {
+                        "hint": "Anzahl der einzelnen Ziele, die betroffen sein können.",
+                        "label": "Anzahl Ziele"
+                    },
+                    "label": "Betroffene Ziele",
+                    "special": {
+                        "hint": "Beschreibung für jede spezielle Ziel.",
+                        "label": "Spezielle Ziele"
+                    },
+                    "type": {
+                        "hint": "Art der Ziele, die betroffen sein können (z. B. Kreaturen, Objekte, Räume).",
+                        "label": "Zielart"
+                    }
+                },
+                "label": "Ziele",
+                "override": {
+                    "hint": "Verwende diese Zielwerte anstelle der Items, wenn du diese Aktivität verwendest.",
+                    "label": "Überschreibe Ziel"
+                },
+                "prompt": {
+                    "hint": "Sollte der Spieler aufgefordert werden, eine Messschablone zu platzieren? Spieler können weiterhin Vorlagen von der Chat-Karte platzieren, wenn die Aufforderung deaktiviert ist.",
+                    "label": "Vorlagenabfrage für Messschablone"
+                },
+                "template": {
+                    "contiguous": {
+                        "hint": "Müssen alle geschaffenen Bereiche miteinander verbunden sein?",
+                        "label": "Angrenzende Bereiche"
+                    },
+                    "count": {
+                        "hint": "Anzahl der verschiedenen Bereiche, die gezielt angewählt werden können.",
+                        "label": "Anzahl Bereiche"
+                    },
+                    "height": {
+                        "hint": "Height of a cylinder affected if applicable.",
+                        "label": "Bereichshöhe"
+                    },
+                    "label": "Wirkungsbereich",
+                    "size": {
+                        "hint": "Größe des Wirkungsbereichs auf seiner Hauptachse.",
+                        "label": "Bereichsgröße"
+                    },
+                    "type": {
+                        "hint": "Art des Zielbereichs.",
+                        "label": "Bereichstyp"
+                    },
+                    "units": {
+                        "hint": "Einheiten zur Messung der Größe von Wirkungsbereichen.",
+                        "label": "Bereicheinheit"
+                    },
+                    "width": {
+                        "hint": "Breite einer Linie wenn verfügbar.",
+                        "label": "Bereichsbreite"
+                    }
+                }
+            }
+        },
+        "Warning": {
+            "PlaceTemplate": "Die Messschablone konnte nicht platziert werden."
+        }
+    },
+    "DND5E.TMP": "TMP",
+    "DND5E.TOOL": "{'SECTIONS': {'Details': '{label} Details', 'Bonuses': {'Label': '{label} Boni', 'Hint': 'Diese Boni gelten für Proben, die mit {label} durchgeführt werden.'}, 'Global': {'Label': 'Globale Boni', 'Hint': 'Diese Boni gelten für Proben, die mit einem beliebigen Werkzeug durchgeführt werden.'}}}",
+    "DND5E.Target": "Ziel",
+    "DND5E.TargetAlly": "Verbündeter",
+    "DND5E.TargetAny": "Beliebig",
+    "DND5E.TargetCircle": "Kreis",
+    "DND5E.TargetCone": "Kegel",
+    "DND5E.TargetCreature": "Kreatur",
+    "DND5E.TargetCreatureOrObject": "Kreatur oder Objekt",
+    "DND5E.TargetCube": "Würfel",
+    "DND5E.TargetCylinder": "Zylinder",
+    "DND5E.TargetEnemy": "Feind",
+    "DND5E.TargetEvery": "Jede",
+    "DND5E.TargetLine": "Linie",
+    "DND5E.TargetObject": "Objekt",
+    "DND5E.TargetPl": "Ziele",
+    "DND5E.TargetRadius": "Radius",
+    "DND5E.TargetRadiusLegacy": "Radius",
+    "DND5E.TargetSelf": "Selbst",
+    "DND5E.TargetSpace": "Raum",
+    "DND5E.TargetSphere": "Kugel",
+    "DND5E.TargetSquare": "Quadrat",
+    "DND5E.TargetType": "Zielart",
+    "DND5E.TargetTypeArea": "Bereich",
+    "DND5E.TargetTypeIndividual": "Gezielt",
+    "DND5E.TargetUnits": "Bereichseffekt-Einheit",
+    "DND5E.TargetValue": "Ziellänge oder Anzahl",
+    "DND5E.TargetWall": "Wand",
+    "DND5E.TargetWidth": "Linienbreite",
+    "DND5E.TargetWilling": "Bereitwillige Kreatur",
+    "DND5E.Temp": "Temp",
+    "DND5E.TemplatePrompt": "Vorlagenabfrage",
+    "DND5E.TemplatePromptTooltip": "Wenn nicht aktiviert, wird die Abfrage zum platzieren einer Vorlage unterdrückt.",
+    "DND5E.Threshold": "Schwellenwert",
+    "DND5E.TimeDay": "Tage",
+    "DND5E.TimeDayAbbr": "t",
+    "DND5E.TimeDisp": "Bis der Zauber gebannt wird",
+    "DND5E.TimeDispTrig": "Bis der Zauber gebannt oder ausgelöst wird",
+    "DND5E.TimeHour": "Stunden",
+    "DND5E.TimeHourAbbr": "h",
+    "DND5E.TimeInst": "Sofort",
+    "DND5E.TimeMinute": "Minuten",
+    "DND5E.TimeMinuteAbbr": "m",
+    "DND5E.TimeMonth": "Monate",
+    "DND5E.TimePerm": "Permanent",
+    "DND5E.TimeRound": "Runden",
+    "DND5E.TimeTurn": "Züge",
+    "DND5E.TimeYear": "Jahre",
+    "DND5E.ToHit": "Trefferbonus",
+    "DND5E.ToggleDescription": "Beschreibung umschalten",
+    "DND5E.TokenRings": {
+        "BackgroundColor": "Hintergrundfarbe",
+        "Effects": {
+            "BackgroundWave": "Hintergrundwelle",
+            "Label": "Effekte",
+            "RingGradient": "Ring Farbverlauf",
+            "RingPulse": "Ring-Puls"
+        },
+        "Enabled": "Dynamischen Ring verwenden",
+        "RingColor": "Ringfarbe",
+        "ScaleCorrection": "Skala Korrektur",
+        "Subject": {
+            "Hint": "Geben Sie explizit einen Pfad für das über dem dynamischen Token-Ring platzierte Bildmaterial an. Wird kein Pfad angegeben, so wird versucht, das Bildmotiv durch Hinzufügen von \"-subject\" am Ende des normalen Pfads für das Token-Bild zu ermitteln.",
+            "Label": "Subjekt Pfad"
+        },
+        "Title": "Dynamischer Ring"
+    },
+    "DND5E.Tokens": {
+        "NoneSelected": "Kein Token ausgewählt",
+        "NoneTargeted": "Kein Token anvisiert",
+        "Selected": "Ausgewählt",
+        "Targeted": "Anvisiert"
+    },
+    "DND5E.ToolArtisans": "Handwerkerausrüstung",
+    "DND5E.ToolBonuses": "Werkzeugboni",
+    "DND5E.ToolCheck": "Werkzeugprobe",
+    "DND5E.ToolConfigure": "Übung mit Werkzeug bearbeiten",
+    "DND5E.ToolDisguiseKit": "Verkleidungsausrüstung",
+    "DND5E.ToolForgeryKit": "Fälscherausrüstung",
+    "DND5E.ToolGamingSet": "Spiel",
+    "DND5E.ToolHerbalismKit": "Kräuterkundeausrüstung",
+    "DND5E.ToolMusicalInstrument": "Musikinstrument",
+    "DND5E.ToolNavigators": "Navigationswerkzeuge",
+    "DND5E.ToolPoisonersKit": "Giftmischerausrüstung",
+    "DND5E.ToolPromptTitle": "{tool}-Probe",
+    "DND5E.ToolThieves": "Diebeswerkzeug",
+    "DND5E.ToolVehicle": "Fahrzeug",
+    "DND5E.TraitAll": "Alle {category}",
+    "DND5E.TraitArmorLegacyPlural.one": "Übung mit Rüstung",
+    "DND5E.TraitArmorLegacyPlural.other": "Übung mit Rüstungen",
+    "DND5E.TraitArmorLegacyProf": "Übung mit Rüstung",
+    "DND5E.TraitArmorPlural.one": "Übung mit Rüstung",
+    "DND5E.TraitArmorPlural.other": "Übung mit Rüstungen",
+    "DND5E.TraitArmorProf": "Übung mit Rüstung",
+    "DND5E.TraitCIPlural.one": "Zustandsimmunität",
+    "DND5E.TraitCIPlural.other": "Zustandsimmunitäten",
+    "DND5E.TraitConfig": "{trait} bearbeiten",
+    "DND5E.TraitConfigChooseAnyCounted": "jede {count} {type}",
+    "DND5E.TraitConfigChooseAnyUncounted": "jede {type}",
+    "DND5E.TraitConfigChooseList": "{count} aus {list}",
+    "DND5E.TraitConfigChooseOther": "{count} andere {type}",
+    "DND5E.TraitConfigChooseWrapper": "Wähle {choices}",
+    "DND5E.TraitDIPlural.one": "Schadensimmunität",
+    "DND5E.TraitDIPlural.other": "Schadensimmunitäten",
+    "DND5E.TraitDMPlural.one": "Schadensmodifikator",
+    "DND5E.TraitDMPlural.other": "Schadensmodifikatoren",
+    "DND5E.TraitDRPlural.one": "Schadensresistenz",
+    "DND5E.TraitDRPlural.other": "Schadensresistenzen",
+    "DND5E.TraitDVPlural.one": "Schadensanfälligkeit",
+    "DND5E.TraitDVPlural.other": "Schadensanfälligkeiten",
+    "DND5E.TraitGenericPlural.one": "Merkmal",
+    "DND5E.TraitGenericPlural.other": "Merkmale",
+    "DND5E.TraitLanguagesPlural.one": "Sprache",
+    "DND5E.TraitLanguagesPlural.other": "Sprachen",
+    "DND5E.TraitSave": "Speichern",
+    "DND5E.TraitSavesPlural.one": "Übung mit Rettungswurf",
+    "DND5E.TraitSavesPlural.other": "Übung mit Rettungswürfen",
+    "DND5E.TraitSelectorSpecial": "Spezial (durch Semikolon getrennt)",
+    "DND5E.TraitSkillsPlural.one": "Übung in Fertigkeit",
+    "DND5E.TraitSkillsPlural.other": "Übung in Fertigkeiten",
+    "DND5E.TraitToolPlural.one": "Übung mit Werkzeug",
+    "DND5E.TraitToolPlural.other": "Übung mit Werkzeugen",
+    "DND5E.TraitToolProf": "Übung mit Werkzeug",
+    "DND5E.TraitWeaponPlural.one": "Übung mit Waffe",
+    "DND5E.TraitWeaponPlural.other": "Übung mit Waffen",
+    "DND5E.TraitWeaponProf": "Übung mit Waffen",
+    "DND5E.Traits": "Eigenschaften",
+    "DND5E.TraitsChosen": "Gewählte Eigenschaften",
+    "DND5E.Trigger": "Auslöser",
+    "DND5E.Type": "Typ",
+    "DND5E.USAGE": {
+        "SECTION": {
+            "Consumption": "Verbrauch",
+            "Creation": "Erstellen",
+            "Scaling": "Skalierung"
+        }
+    },
+    "DND5E.USES": {
+        "FIELDS": {
+            "uses": {
+                "label": "Nutzungen",
+                "max": {
+                    "hint": "Formel für die maximale Anzahl von Nutzungen",
+                    "label": "Maximale Nutzungen"
+                },
+                "recovery": {
+                    "FIELDS": {
+                        "formula": {
+                            "hint": "Formel zur Bestimmung der Anzahl der wiederhergestellten Nutzungen.",
+                            "label": "Wiederherstellungsformel"
+                        },
+                        "period": {
+                            "hint": "Zeitpunkt, zu dem diese Wiedederherstellung eintreten wird.",
+                            "label": "Wiederherstellungsperiode"
+                        },
+                        "type": {
+                            "hint": "Wie Nutzungen wiederhergestellt werden.",
+                            "label": "Wiederherstellungstyp"
+                        }
+                    },
+                    "hint": "Wiederherstellungsprofile für dies Nutzungen dieser Aktivität",
+                    "label": "Nutzung Wiederherstellung"
+                },
+                "spent": {
+                    "hint": "Anzahl der Nutzungen die verbraucht werden.",
+                    "label": "Verbrauche Nutzung"
+                }
+            }
+        },
+        "Recovery": {
+            "Action": {
+                "Create": "Erstelle Wiederherstellungsprofil",
+                "Delete": "Entferne Wiederherstellungsprofil"
+            },
+            "Recharge": {
+                "Label": "Wiederaufladen",
+                "Range": "Wiederaufladen {range}"
+            },
+            "Type": {
+                "Formula": "Eigene Formel",
+                "LoseAll": "Alle Nutzungen verlieren",
+                "RecoverAll": "Alle Nutzungen Wiederherstellen"
+            }
+        }
+    },
+    "DND5E.UTILITY": {
+        "FIELDS": {
+            "roll": {
+                "formula": {
+                    "hint": "Formel für einen beliebigen Wurf.",
+                    "label": "Wurf Formel"
+                },
+                "label": "Utility Wurf",
+                "name": {
+                    "hint": "Beschiftung für den Wurfknopf",
+                    "label": "Wurf Beschriftung"
+                },
+                "prompt": {
+                    "hint": "Sollte das Dialogfeld „Wurfkonfiguration“ beim Würfeln angezeigt werden?",
+                    "label": "Utility Wurf Abfrage"
+                },
+                "visible": {
+                    "hint": "Soll der Wurfknopf für alle Spieler sichtbar sein?",
+                    "label": "Sichtbar für Alle"
+                }
+            }
+        },
+        "Title": "Utility"
+    },
+    "DND5E.Uncrewed": "Unbemannt",
+    "DND5E.Unequipped": "Nicht angelegt",
+    "DND5E.Unidentified.DefaultName": "Unidentifiziert: {name}",
+    "DND5E.Unidentified.Notice": "Du musst das Item identifizieren um die details zu erfahren.",
+    "DND5E.Unidentified.Title": "Unidentifiziert",
+    "DND5E.Unidentified.Value": "???",
+    "DND5E.Unknown": "Unbekannt",
+    "DND5E.Unlimited": "Unbegrenzt",
+    "DND5E.Usage": "Nutzung",
+    "DND5E.Use": "benutzen",
+    "DND5E.UseItem": "Use {item}",
+    "DND5E.Uses": "Nutzungen",
+    "DND5E.UsesAvailable": "Verbleibende  Nutzungen",
+    "DND5E.UsesMax": "Maximale Nutzungen",
+    "DND5E.UsesPeriod": "Aufladungszeit",
+    "DND5E.UsesPeriods": {
+        "AtWill": "Nach Belieben",
+        "Charges": "Aufladungen",
+        "ChargesAbbreviation": "Aufladungen",
+        "Dawn": "Morgengrauen",
+        "DawnAbbreviation": "Morgengrauen",
+        "Day": "Tag",
+        "DayAbbreviation": "Tag",
+        "Dusk": "Dämmerung",
+        "DuskAbbreviation": "Dämmerung",
+        "Lr": "Lange Rast",
+        "LrAbbreviation": "LR",
+        "Never": "Niemals",
+        "Sr": "Kurze Rast",
+        "SrAbbreviation": "KR"
+    },
+    "DND5E.Value": "Wert",
+    "DND5E.Vehicle": "Fahrzeug",
+    "DND5E.VehicleActionMax": "Max. Aktionen",
+    "DND5E.VehicleActionStations": "Aktionsstationen",
+    "DND5E.VehicleActionThresholds": "Aktionsschwellenwerte",
+    "DND5E.VehicleActionThresholdsFull": "Volle Besatzung",
+    "DND5E.VehicleActionThresholdsMid": "Teilweise Besatzung",
+    "DND5E.VehicleActionThresholdsMin": "Minimale Besatzung",
+    "DND5E.VehicleActions": "Aktionen",
+    "DND5E.VehicleActionsHint": "Aktionen mit voller Besatzung",
+    "DND5E.VehicleCargo": "Fracht",
+    "DND5E.VehicleCargoCapacity": "Frachtkapazität",
+    "DND5E.VehicleCargoCrew": "Fracht/Besatzung",
+    "DND5E.VehicleCreatureCapacity": "Besatzungskapazität",
+    "DND5E.VehicleCrew": "Besatzung",
+    "DND5E.VehicleCrewAction": "Besatzungsaktion",
+    "DND5E.VehicleCrewPassengers": "Besatzung & Passagiere",
+    "DND5E.VehicleCrewed": "Bemannt",
+    "DND5E.VehicleEquipment": "Fahrzeugausstattung",
+    "DND5E.VehicleMishap": "Panne",
+    "DND5E.VehicleMishapThreshold": "Unfall Grenzwert",
+    "DND5E.VehiclePassengerName": "Passagiername oder Typ",
+    "DND5E.VehiclePassengerQuantity": "Passagierzahl",
+    "DND5E.VehiclePassengers": "Passagiere",
+    "DND5E.VehicleType": "Fahrzeugtyp",
+    "DND5E.VehicleTypeAir": "Luftfahrzeug",
+    "DND5E.VehicleTypeLand": "Landfahrzeug",
+    "DND5E.VehicleTypeSpace": "Weltraumfahrzeug",
+    "DND5E.VehicleTypeWater": "Wasserfahrzeug",
+    "DND5E.VehicleUncrewed": "Unbemannt",
+    "DND5E.Versatile": "Vielseitig",
+    "DND5E.VersatileDamage": "Vielseitig: Schaden",
+    "DND5E.VsDC": "gg. SG.",
+    "DND5E.Vulnerabilities": "Verwundbarkeiten",
+    "DND5E.WEAPON": {
+        "FIELDS": {
+            "ammunition": {
+                "type": {
+                    "label": "Munitionstyp"
+                }
+            },
+            "damage": {
+                "hint": "Würfel für intrinsische Schäden der Waffe. Modifikatoren für Attribute und zusätzliche Schadensbestandteile werden beim Angriff automatisch bereitgestellt."
+            },
+            "mastery": {
+                "hint": "Spezielles Waffenattribut für Charaktere freigeschaltet, die die Waffenmeisterschaft oder ein verwandtes Merkmal besitzen.",
+                "label": "Meisterschaft"
+            }
+        },
+        "Mastery": {
+            "Cleave": "Spalten",
+            "Flavor": "Meisterschaft",
+            "Graze": "Streifen",
+            "Label": "Waffenmeisterschaft",
+            "Nick": "Schwingen",
+            "Push": "Stoßen",
+            "Sap": "Betäuben",
+            "Slow": "Verlangsamen",
+            "Topple": "Stürzen",
+            "Vex": "Wüten"
+        }
+    },
+    "DND5E.WarnBadACFormula": "Die genutzte RK-Formel konnte nicht evaluiert werden.",
+    "DND5E.WarnCantAddMultipleAdvancements": "Es ist momentan nicht möglich, gleichzeitig mehrere Items mit Fortschritten einem Akteur hinzuzufügen. Bitte Items einzeln hinzufügen.",
+    "DND5E.WarnMultipleArmor": "Mehr als eine Rüstung ausgerüstet, RK-Berechnung ist möglicherweise inkorrekt.",
+    "DND5E.WarnMultipleShields": "Mehr als ein Schild ausgerüstet, RK-Berechnung ist möglicherweise inkorrekt.",
+    "DND5E.WeaponCategory": "{category} Waffe",
+    "DND5E.WeaponImprov": "Improvisiert",
+    "DND5E.WeaponMartialM": "Kriegswaffe Nah.",
+    "DND5E.WeaponMartialProficiency": "Übung Kriegswaffen",
+    "DND5E.WeaponMartialR": "Kriegswaffe Fern.",
+    "DND5E.WeaponNatural": "Natürlich",
+    "DND5E.WeaponOtherProficiency": "Andere",
+    "DND5E.WeaponSiege": "Belagerungswaffe",
+    "DND5E.WeaponSimpleM": "Einfache Waffe Nah.",
+    "DND5E.WeaponSimpleProficiency": "Übung Einfache Waffen",
+    "DND5E.WeaponSimpleR": "Einfache Waffe Fern.",
+    "DND5E.Weight": "Gewicht",
+    "DND5E.WeightUnit": {
+        "Kilograms": {
+            "Abbreviation": "kg",
+            "Label": "Kilogramm"
+        },
+        "Label": "Gewichtseinheiten",
+        "Megagrams": {
+            "Abbreviation": "t",
+            "Label": "Tonnen"
+        },
+        "Pounds": {
+            "Abbreviation": "lb",
+            "Label": "Pfund"
+        },
+        "Tons": {
+            "Abbreviation": "tn",
+            "Label": "Tonnen"
+        }
+    },
+    "DND5E.WhisperedTo": "Flüstern zu",
+    "DND5E.Wiki": "Wiki",
+    "DND5E.available": "verfügbar",
+    "DND5E.description": "Ein umfassendes Spielsystem zum Spielen der Dungeons & Dragons 5. Edition in Foundry VTT.",
+    "DND5E.of": "von",
+    "DND5E.per": "per",
+    "DND5E.spell": "Zauber",
+    "DND5E.title": "Dungeons & Dragons 5. Edition",
+    "DOCUMENT.DND5E": {
+        "Activity": "Aktivität"
+    },
+    "EDITOR.DND5E.Inline": {
+        "ApplyStatus": "Status auf ausgewählte Token anwenden",
+        "AwardEach": "{award} jeden",
+        "CheckLong": "{check} prüfung",
+        "CheckShort": "{check}",
+        "DC": "SG {dc} {check}",
+        "DCPassiveLong": "passiver {check} Wert von {dc} oder höher",
+        "DCPassiveShort": "SG {dc} passiver {check}",
+        "DamageLong": "{average} ({formula}) {type}",
+        "DamageShort": "{formula} {type}",
+        "NoActorWarning": "Es konnte kein ausgewählter oder zugewiesener Akteur gefunden werden, um den Wurf auszuführen",
+        "RequestRoll": "Wurf anfragen",
+        "RollRequest": "Anfragen eines Wurfes",
+        "SaveLong": "{save} Rettungswurf",
+        "SaveShort": "{save}",
+        "SpecificCheck": "{ability} ({type})",
+        "Warning": {
+            "NoActivityOnItem": "{item} von {actor} hat keine Aktivität mit dem Namen {activity}.",
+            "NoActor": "Es konnte kein ausgewählter oder zugewiesener Akteur gefunden werden um diesen Wurf auszuführen",
+            "NoItemOnActor": "{actor} hat kein Item mit dem Namen {item}."
+        }
+    },
+    "EFFECT.DND5E": {
+        "StatusBleeding": "Bluten",
+        "StatusBloodied": "Blutig",
+        "StatusBurning": "Brennend",
+        "StatusBurrowing": "Eingraben",
+        "StatusConcentrating": "Konzentration",
+        "StatusCursed": "Verflucht",
+        "StatusDead": "Tod",
+        "StatusDehydration": "Dehydrierung",
+        "StatusDodging": "Ausweichen",
+        "StatusEncumbered": "Belastet",
+        "StatusEthereal": "Ätherisch",
+        "StatusExceedingCarryingCapacity": "Überschreitung der Traglastt",
+        "StatusFalling": "Fallend",
+        "StatusFlying": "Fliegen",
+        "StatusHalfCover": "Halbe Deckung",
+        "StatusHeavilyEncumbered": "Stark belastet",
+        "StatusHiding": "Verstecken",
+        "StatusHovering": "Schweben",
+        "StatusMalnutrition": "Unterernährung",
+        "StatusMarked": "Markiert",
+        "StatusSilenced": "Stumm",
+        "StatusSleeping": "Schlafen",
+        "StatusStable": "Stabil",
+        "StatusSuffocation": "Ersticken",
+        "StatusSurprised": "Überrascht",
+        "StatusThreeQuartersCover": "Dreivierteldeckung",
+        "StatusTotalCover": "Vollständige Deckung",
+        "StatusTransformed": "Verwandelt"
+    },
+    "JOURNALENTRYPAGE.DND5E": {
+        "Class": {
+            "EquipmentDescription": "Du beginnst mit der folgenden Ausrüstung, zusätzlich zu der, die du durch deinen Hintergrund erhältst:",
+            "EquipmentHeader": "Ausrüstung",
+            "FIELDS": {
+                "description": {
+                    "additionalEquipment": {
+                        "hint": "Zusätzlicher beschreibender Text, der unter dem Startausrüstungsabschnitt angezeigt wird.",
+                        "label": "Zusätzliche Ausrüstung Beschreibung"
+                    },
+                    "additionalHitPoints": {
+                        "hint": "Zusätzlicher beschreibender Text, der unter dem automatisch generierten Trefferpunkte Abschnitt angezeigt wird.",
+                        "label": "Zusätzliche Trefferpunkte Beschreibung"
+                    },
+                    "additionalTraits": {
+                        "hint": "Zusätzlicher beschreibender Text, der unter der Liste der von dieser Klasse gewährten Übungen angezeigt wird.",
+                        "label": "Zusätzliche Übungen Beschreibung"
+                    },
+                    "subclass": {
+                        "hint": "Einleitung, die vor den Unterklassen dieser Klasse angezeigt wird.",
+                        "label": "Unterklassen-Einleitung"
+                    },
+                    "value": {
+                        "hint": "Grundsätzliche Beschreibung der Klasse. Wird zuerst angezeigt.",
+                        "label": "Einleitung"
+                    }
+                },
+                "item": {
+                    "label": "Gewählte Klasse"
+                },
+                "style": {
+                    "hint": "Erzwinge die Verwendung der Modernen oder Legacy-Formatierung für den Seitenstil, anstatt des durch die Klasse festgelegten.",
+                    "label": "Stil"
+                },
+                "subclassHeader": {
+                    "label": "Unterklassenabschnitt"
+                },
+                "subclassItems": {
+                    "label": "Unterklassen"
+                }
+            },
+            "Features": {
+                "DescriptionLegacy": "Als {name} erhältst du die folgenden Klassenmerkmale, die in der {name}-Tabelle zusammengefasst werden.",
+                "DescriptionModern": "Als ein {name}, erhältst du die folgenden Klassenmerkmale wenn du die spezifische {name} Stufe erreichst. Die Merkmale sind in der {name} Merkmale Tabelle gelistet.",
+                "Header": "Klassenmerkmale",
+                "Name": "Stufe {level}: {name}"
+            },
+            "HitPoints": {
+                "Header": "Trefferpunkte",
+                "HitDiceLegacy": "<strong>Trefferwürfel:</strong> {dice} pro Stufe als {class}",
+                "HitDiceModern": "{dice} pro {class} Stufe",
+                "Level1": "<strong>Trefferpunkte auf Stufe 1:</strong> {max} + dein Konstitutionsmodifikator",
+                "LevelX": "<strong>Trefferpunkte auf höheren Stufen:</strong> {dice} (oder {average}) + dein Konstitutionsmodifikator pro Stufe als {class} über die 1. Stufe hinaus"
+            },
+            "ItemHint": "Klasse hierhin ziehen",
+            "NoValidClass": "Keine gültige Klasse gewählt, Bearbeiten nutzen um eine Klasse hinzuzufügen.",
+            "OptionalFeaturesCaption": "Optionale Klassenmerkmale",
+            "OptionalFeaturesDescription": "Der folgende Abschnitt enthält optionale {class}-Klassenmerkmale. Diese werden nicht automatisch zugewiesen und können einzeln, alle oder nach Wahl der Spielleitung gewählt werden.",
+            "SpellSlotLevel": "Platzgrad",
+            "SpellSlots": "Zauberplätze",
+            "SpellSlotsPerSpellLevel": "—Zauberplätze pro Grad—",
+            "Style": {
+                "Inferred": "Aus Quelle abgeleitet",
+                "Legacy": "Legacy",
+                "Modern": "Modern"
+            },
+            "SubclassHint": "Unterklassen hierhin ziehen",
+            "TableCaption": "{class}",
+            "TableOptionalCaption": "Optionale {class}-Klassenmerkmale",
+            "Traits": {
+                "Caption": "{class} Kernmerkmale",
+                "Header": "Übung"
+            }
+        },
+        "EditDescription": "Bearbeiten",
+        "SpellList": {
+            "DropHint": "Zauber oder Ordner mit Zaubern hierhin ziehen um die Liste zu ergänzen",
+            "Grouping": {
+                "Alphabetical": "Nach Anfangsbuchstaben",
+                "Hint": "Legt fest, wie die Zauber standardmäßig in der Zauberliste gruppiert werden sollen.",
+                "Label": "Gruppierungsmodus",
+                "Level": "Nach Zaubergrad",
+                "None": "Keine Gruppierung",
+                "School": "Nach Zauberschule"
+            },
+            "IdentifierHint": "Die ID sollte mit der im zugehörigen Dokument definierten ID übereinstimmen, falls zutreffend. Bei der Erstellung einer Zauberliste für die Klasse \"Magier\" sollte die ID beispielsweise \"Magier\" lauten.",
+            "Type": {
+                "Label": "Zauberlisten-Typ",
+                "Other": "Unkategorisiert"
+            },
+            "UnlinkedSpells": {
+                "Add": "Unverlinkte Zauber hinzufügen",
+                "Configuration": "Zauberkonfiguration",
+                "Edit": "Unverlinkte Zauber bearbeiten",
+                "Label": "Unverlinkte Zauber"
+            }
+        },
+        "Subclass": {
+            "FIELDS": {
+                "description": {
+                    "value": {
+                        "hint": "Grundsätzliche Beschreibung der Unterklasse. Wird zuerst angezeigt.",
+                        "label": "Einleitung"
+                    }
+                },
+                "item": {
+                    "label": "Gewählte Unterklasse"
+                },
+                "style": {
+                    "hint": "Force the page style to use modern or legacy formatting, rather than what is specified by the subclass.",
+                    "label": "Stil"
+                }
+            },
+            "ItemHint": "Unterklasse hierhin ziehen",
+            "NoValidSubclass": "Keine gültige Unterklasse gewählt, Bearbeiten nutzen um eine Unterlasse hinzuzufügen."
+        },
+        "TableTOC": "Tabelle: {caption}"
+    },
+    "KEYBINDINGS.DND5E.SkipDialogAdvantage": "Überspringe Dialog (Wurf mit Vorteil/Kritisch)",
+    "KEYBINDINGS.DND5E.SkipDialogDisadvantage": "Überspringe Dialog (Wurf mit Nachteil)",
+    "KEYBINDINGS.DND5E.SkipDialogNormal": "Überspringe Dialog",
+    "MACRO.5eMissingTargetWarn": "Dein kontrollierter Akteur '{actor}' hat kein(en) {type} mit Namen '{name}'.",
+    "MACRO.5eMultipleTargetsWarn": "Dein kontrollierter Akteur '{actor}' hat mehr als ein(en) {type} mit Namen '{name}'. Der erste Treffer wird genutzt.",
+    "MACRO.5eNoActorSelected": "Kein gewählter oder zugewiesener Akteur konnte als Ziel für Makro gefunden werden.",
+    "MACRO.5eUnownedWarn": "Du kannst nur Makrobuttons für Items erstellen, die dir gehören",
+    "MIGRATION.5eBegin": "Migriere DnD5E System zu Version {version}. Bitte Geduld haben und das Spiel nicht schließen oder beenden.",
+    "MIGRATION.5eComplete": "DnD5E System-Migration zu Version {version} abgeschlossen!",
+    "MIGRATION.5eVersionTooOldWarning": "Die DnD5e-Systemdaten stammen von einer zu alten Foundry-Version und können nicht verlässlich migriert werden. Ein Versuch wird unternommen, aber Fehler können auftreten.",
+    "SETTINGS.5eAllowPolymorphingL": "Erlaube den Spielern, ihre eigenen Charaktere zu verwandeln.",
+    "SETTINGS.5eAllowPolymorphingN": "Verwandlung zulassen",
+    "SETTINGS.5eAttackRollVisibility": {
+        "All": "Zeige Ergebnisse und RK vom Ziel",
+        "HideAC": "Zeige nur Ergebnisse",
+        "Hint": "Kontrolliere die Sichtbarkeit der Ergebnisse von Angriffswürfen in Chat-Karten für Spieler.",
+        "Name": "Angriffsergebnis Sichtbarkeit",
+        "None": "Verstecke alle"
+    },
+    "SETTINGS.5eAutoCollapseCardL": "Objektkartenbeschreibungen im Chat-Protokoll automatisch zusammenklappen",
+    "SETTINGS.5eAutoCollapseCardN": "Objektkarten im Chat zusammenklappen",
+    "SETTINGS.5eAutoSpellTemplateL": "Wenn ein Zauberspruch gewirkt wird, beginnt standardmäßig der Prozess zur Erstellung der entsprechenden Messschablone, falls vorhanden (erfordert die Spielerrolle TRUSTED) oder eine höhere Rolle",
+    "SETTINGS.5eAutoSpellTemplateN": "Messschablone immer platzieren",
+    "SETTINGS.5eChallengeVisibility": {
+        "All": "Zeige alle",
+        "Hint": "Lege fest, welche Wurf-SGs für die Spieler sichtbar sind und ob Erfolge/Fehlschäge hervorgehoben werden.",
+        "Name": "Schwieriegkeitsgrad Sichtbarkeit",
+        "None": "Verstecke alle",
+        "Player": "Nur von anderen Spielern zeigen"
+    },
+    "SETTINGS.5eCriticalMaxDiceL": "Macht kritische Treffer tödlicher, indem die Werte der Schadenswürfel maximiert werden.",
+    "SETTINGS.5eCriticalMaxDiceN": "Kritischer Schaden Würfel Maximieren",
+    "SETTINGS.5eCriticalModifiersL": "Macht kritischer Treffer tödlicher, indem auch Boni zusätzlich zu den Würfelergebnissen multipliziert werden.",
+    "SETTINGS.5eCriticalModifiersN": "Kritischer Schaden Boni Multiplizieren",
+    "SETTINGS.5eCurWtL": "Mitgeführte Währung beeinflusst die Tragebelastung nach den Regeln des SHB S. 143.",
+    "SETTINGS.5eCurWtN": "Währung hat Gewicht",
+    "SETTINGS.5eDiagDMG": "Spielleiterhandbuch (5/10/5)",
+    "SETTINGS.5eDiagEuclidean": "Euklidisch (7,07 ft. Diagonale)",
+    "SETTINGS.5eDiagL": "Bearbeite, welche Diagonalbewegungsregel für Spiele innerhalb dieses Systems verwendet werden soll.",
+    "SETTINGS.5eDiagN": "Diagonale Bewegungs Regeln",
+    "SETTINGS.5eDiagPHB": "Spielerhandbuch (5/5/5)",
+    "SETTINGS.5eEncumbrance": {
+        "Hint": "Ermöglicht die automatische Verfolgung der Belastung und die Anwendung von Statuseffekten für Charaktere, die zu viel tragen.",
+        "Name": "Verfolgung von Belastung",
+        "None": "keine",
+        "Normal": "Normal (maximale Traglast)",
+        "Variant": "Variante (belastet & stark belastet)"
+    },
+    "SETTINGS.5eFeatsL": "Erlaubt Spielern beim Klassenaufstieg, Talente anstelle einer Attributswerterhöhung zu wählen.",
+    "SETTINGS.5eFeatsN": "Talente erlauben",
+    "SETTINGS.5eGridAlignedSquareTemplatesL": "Wenn quadratische Schablonen durch das Wirken eines Zaubers oder die Verwendung eines Gegenstands erstellt werden, sind sie an die Ausrichtung des Rasters gebunden und können nicht gedreht werden.",
+    "SETTINGS.5eGridAlignedSquareTemplatesN": "Am Raster ausgerichtete quadratische Schablonen",
+    "SETTINGS.5eHonorL": "Aktiviert die Nutzung des optionalen Ehrenwerts. Erfordert, dass die Welt neu geladen wird.",
+    "SETTINGS.5eHonorN": "Ehre",
+    "SETTINGS.5eInitTBL": "Zähle den Attributswert (GE) zur INI hinzu um Gleichstand zu vermeiden.",
+    "SETTINGS.5eInitTBN": "INI GE Mod",
+    "SETTINGS.5eMetricL": "Ersetzt alle Instanzen von Pfund (lb) mit Kilogramm (kg) und aktualisiert die Traglastberechnung um metrische Einheiten.",
+    "SETTINGS.5eMetricN": "Nutze metrische Gewichtseinheiten",
+    "SETTINGS.5eNoAdvancementsL": "Bei Stufenaufstieg und Charaktererstellung keine Auswahl abfragen.",
+    "SETTINGS.5eNoAdvancementsN": "Stufenaufstieg nicht automatisieren",
+    "SETTINGS.5eNoConcentrationL": "Deaktivieren Sie die automatische Verfolgung der Konzentration durch das System.",
+    "SETTINGS.5eNoConcentrationN": "Konzentrationsverfolgung deaktivieren",
+    "SETTINGS.5eProfBonus": "PHB: Bonus (+2, +3, +4, +5, +6)",
+    "SETTINGS.5eProfDice": "DMG: Würfel (1d4, 1d6, 1d8, 1d10, 1d12)",
+    "SETTINGS.5eProfL": "Konfiguration von Übungsbonus: fester Wert oder Würfelwurf. Neuladen der Welt ist erforderlich, damit eine Änderung wirksam wird.",
+    "SETTINGS.5eProfN": "Übungsvariante",
+    "SETTINGS.5eReset": "Zurücksetzen",
+    "SETTINGS.5eRestEpic": "Episches Heldentum (LR: 1 Std., KR: 1 Min.)",
+    "SETTINGS.5eRestGritty": "Rauer Realismus (LR: 7 Tage, KR: 8 Std.)",
+    "SETTINGS.5eRestL": "Bearbeite, welche Rastregel für Spiele innerhalb dieses Systems verwendet werden soll.",
+    "SETTINGS.5eRestN": "Rast Variante",
+    "SETTINGS.5eRestPHB": "Spielerhandbuch (LR: 8 Std., KR: 1 Std.)",
+    "SETTINGS.5eSanityL": "Aktiviert die Nutzung des optionalen Werts für Geistige Gesundheit. Erfordert, dass die Welt neu geladen wird.",
+    "SETTINGS.5eSanityN": "Geistige Gesundheit",
+    "SETTINGS.5eTokenRings": {
+        "Hint": "Die Deaktivierung der Token-Ring-Animationen kann die Leistung verbessern.",
+        "Name": "Dynamische Token-Ringe deaktivieren"
+    },
+    "SETTINGS.5eUndoChanges": "Änderungen zurücksetzen",
+    "SETTINGS.DND5E": {
+        "ALLOWSUMMONING": {
+            "Hint": "Erlaubt Spielern, Beschwörungsfähigkeiten zu nutzen, um Akteure zu beschwören. Damit dies funktioniert, müssen die Spieler auch die Berechtigung \"Neue Figuren erstellen\" haben.",
+            "Name": "Beschwörungen erlauben"
+        },
+        "BLOODIED": {
+            "All": "Anzeigen für Verbündete und Feinde",
+            "Hint": "Konfiguriere, ob der Blutig Status automatisch verfolgt wird und dessen Sichtbarkeit.",
+            "Name": "Blutig Status",
+            "None": "Nicht anzeigen",
+            "Player": "Nur für Verbündete Anzeigen"
+        },
+        "COLLAPSETRAYS": {
+            "Always": "Alle einklappen",
+            "Hint": "Automatisches Einklappen von Schadens-, Treffer- und Effektfächern, die in Chat-Karten erscheinen.",
+            "Name": "Fächer im Chat zusammenklappen",
+            "Never": "Alle ausklappen",
+            "Older": "Ältere Fächer zusammenklappen"
+        },
+        "DEFAULTSKILLS": {
+            "Hint": "Die Fertigkeiten, die unabhängig vom Grad der Übung, Standardmäßig auf den NPC-Bögen erscheinen",
+            "Name": "Standard Fertigkeit"
+        },
+        "LEVELING": {
+            "Hint": "Lege fest, wie Spieler neue Stufen aufsteigen.",
+            "Name": "Stufenaufstieg Modus",
+            "NoXP": "Stufenaufstieg ohne EP",
+            "XP": "Erfahrungspunkte",
+            "XPBoons": "Erfahrungspunkte mit Epischen Gaben"
+        },
+        "RULESVERSION": {
+            "Hint": "Ändere die Handhabung verschiedener Regeln zwischen den Regelsätzen von 2024 und 2014",
+            "Legacy": "Legacy Regeln (2014)",
+            "Modern": "Moderne Regeln (2024)",
+            "Name": "Regel Version"
+        },
+        "THEME": {
+            "Hint": "Thema, das standardmäßig auf die Benutzeroberfläche und alle Blätter angewendet wird. Die Automatik wird durch die Einstellungen Ihres Browsers oder Betriebssystems bestimmt.",
+            "Name": "Thema"
+        }
+    },
+    "SHEETS.DND5E": {
+        "THEME": {
+            "Automatic": "Automatisch",
+            "Dark": "Dunkler Modus",
+            "Label": "Thema",
+            "Light": "Heller Modus"
+        }
+    },
+    "SIDEBAR.SortModePriority": "Nach Priorität sortieren",
+    "SOURCE.BOOK.SRD": "System Reference Document 5.1",
+    "TYPES.ActiveEffect.enchantment": "Verzauberung",
+    "TYPES.ActiveEffect.enchantmentPl": "Verzauberungen",
+    "TYPES.Actor.character": "Spielercharakter",
+    "TYPES.Actor.characterPl": "Spielercharaktere",
+    "TYPES.Actor.group": "Gruppe",
+    "TYPES.Actor.groupPl": "Gruppen",
+    "TYPES.Actor.npc": "Nichtspielercharakter",
+    "TYPES.Actor.npcPl": "Nichtspielercharaktere",
+    "TYPES.Actor.vehicle": "Fahrzeug",
+    "TYPES.Actor.vehiclePl": "Fahrzeuge",
+    "TYPES.Item.background": "Hintergrund",
+    "TYPES.Item.backgroundPl": "Hintergründe",
+    "TYPES.Item.class": "Klasse",
+    "TYPES.Item.classPl": "Klassen",
+    "TYPES.Item.consumable": "Verbrauchsgut",
+    "TYPES.Item.consumablePl": "Verbrauchsgüter",
+    "TYPES.Item.container": "Behälter",
+    "TYPES.Item.containerPl": "Behälter",
+    "TYPES.Item.equipment": "Ausrüstung",
+    "TYPES.Item.equipmentPl": "Ausrüstung",
+    "TYPES.Item.feat": "Merkmal",
+    "TYPES.Item.featurePl": "Merkmale",
+    "TYPES.Item.loot": "Beute",
+    "TYPES.Item.lootPl": "Beute",
+    "TYPES.Item.race": "Spezies",
+    "TYPES.Item.raceLegacy": "Volk",
+    "TYPES.Item.raceLegacyPl": "Völker",
+    "TYPES.Item.racePl": "Spezies",
+    "TYPES.Item.spell": "Zauber",
+    "TYPES.Item.spellPl": "Zauber",
+    "TYPES.Item.subclass": "Unterklasse",
+    "TYPES.Item.subclassPl": "Unterklassen",
+    "TYPES.Item.tool": "Werkzeug",
+    "TYPES.Item.toolPl": "Werkzeuge",
+    "TYPES.Item.weapon": "Waffe",
+    "TYPES.Item.weaponPl": "Waffen",
+    "TYPES.JournalEntryPage.class": "Klassenübersicht",
+    "TYPES.JournalEntryPage.map": "Karten Standort",
+    "TYPES.JournalEntryPage.rule": "Regel",
+    "TYPES.JournalEntryPage.spells": "Zauberliste",
+    "TYPES.JournalEntryPage.subclass": "Unterklassenübersicht",
+    "dnd5e-DE.ProficiencyAbbrev": "ÜB"
 }

--- a/languages/de.json
+++ b/languages/de.json
@@ -718,7 +718,7 @@
                 "Warning": "{attribute} Anzahl"
             },
             "HitDice": {
-                "Label": "Tefferwürfel",
+                "Label": "Trefferwürfel",
                 "PromptDecrease": "Trefferwürfel Verbrauchen?",
                 "PromptHintDecrease": "Verbrauche <strong>{cost}</strong> {denomination} {die}.",
                 "PromptHintIncrease": "Wiederherstellen <strong>{cost}</strong> {denomination} {die}.",
@@ -1622,7 +1622,7 @@
         "Label": "Automatische  Trefferwürfel verwenden"
     },
     "DND5E.HitDiceConfig": "Trefferwürfel anpassen",
-    "DND5E.HitDiceConfigHint": "Passt die verbleibenden Tefferwürfelstufen für jede Klasse an.",
+    "DND5E.HitDiceConfigHint": "Passt die verbleibenden Trefferwürfelstufen für jede Klasse an.",
     "DND5E.HitDiceMax": "Maximale Trefferwürfel",
     "DND5E.HitDiceNPCWarn": "{name} hat keine Trefferwürfel übrig!",
     "DND5E.HitDiceRemaining": "Verbleibende Trefferwürfel",


### PR DESCRIPTION
I recently noticed some missing German translations in the D&D 5e system, so I wanted to help fill in the gaps. Using the procedure described in the README, I ran `compare.py` against the latest `en.json` from the foundryvtt/dnd5e master branch, which reflects version 4.1.2 of the system, translated all the missing keys and merged them back into the `de.json` file using `merge.py`.

I also found some keys in the source `en.json` that had been changed, so I updated the `de.json` accordingly. Finally, I also fixed a typo I noticed in the "Save" activity configuration, as well as some inconsistent and unnatural spelling with short and long rests.

Unfortunately, every single line in `de.json` was "changed" because the file used to be indented with 3 spaces, which was changed back to 4 spaces by the `merge.py` script and some of the keys have been shuffled around. So I've listed every significant change I made below:

### Added missing translations

- `DND5E.ABILITY`
- `DND5E.AbilityScoreShort`
- `DND5E.AbilityScoreMaxShort`
- `DND5E.AdvancementScaleValueIdentifierDiceHint`
- `DND5E.ArmorValue`
- `DND5E.CAST`
- `DND5E.EQUIPMENT`
- `DND5E.FORWARD`
- `DND5E.FlagsAlertHintLegacy`
- `DND5E.GlobalBonus`
- `DND5E.HitPointsOverrideHint`
- `DND5E.HitPointsTempMaxHint`
- `DND5E.HITDICE`
- `DND5E.LanguagesCommonSign`
- `DND5E.LongRestHintLegacy`
- `DND5E.LongRestHintGroupLegacy`
- `DND5E.ProficiencyOther`
- `DND5E.ROLL`
- `DND5E.SKILL`
- `DND5E.TOOL`
- `DND5E.TraitDMPlural.one`
- `DND5E.TraitDMPlural.other`

### Fixed existing translations

- `DND5E.SpellPreparation` _(was just a single string, is now an object with three seperate keys in the current version)_
- `DND5E.LongRestHint` _(had been moved to `DND5E.LongRestHintLegacy` and got a new text for the 2024 rules)_
- `DND5E.LongRestHintGroup` _(had been moved to `DND5E.LongRestHintGroupLegacy` and got a new text for the 2024 rules)_

I'm not sure how much this affects backwards compatibility, the long rest translations should be mostly fine, but the change in spell preparation from a single string to an object will most likely not work with older versions of the D&D 5e system. We might also want to update `module.json` to reflect the updated compatibility, but I wasn't sure, so I haven't touched it yet.

### Unified spelling

- In all short and long rest translations:
  - "Rast machen" -> "Rast einlegen"
  - "macht eine kurze/lange Rast" -> "legt eine kurze/lange Rast ein"

### Fixed typos

- `DND5E.SAVE.FIELDS.damage.onSave.label`: "Schaden be iErfolg" -> "Schaden bei Erfolg"
- `DND5E.CONSUMPTION.Type.HitDice.Label`: "Tefferwürfel" -> "Trefferwürfel"
- `DND5E.HitDiceConfigHint`: "Tefferwürfelstufen" -> "Trefferwürfelstufen"

### Still untranslated keys

I wasn't able to confidently translate the following keys, related to bastions and facilities, as I don't yet have access to the new 2024 rules and didn't want to guess their translations:

- `TYPES.Item.facility`
- `TYPES.Item.facilityPl`
- `DND5E.Bastion`
- `DND5E.FACILITY`
- `DND5E.ItemFacilityDetails`

Of course, I removed them from the `diff.txt` before merging, so they are still missing from the `de.json` file. Just wanted to point this out for completeness anyway.